### PR TITLE
Phase 0: HTTP client stabilization, session lifecycle, unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-asyncio
+
+      - name: Run unit tests
+        run: pytest tests/ -m "not integration" -v

--- a/README.en.md
+++ b/README.en.md
@@ -32,50 +32,61 @@ TEAM_ID = 2819  # You can change to any team ID
 PAGE = 0
 
 async def main():
-    client = SofaScoreClient("http://api.sofascore.com")
-    # Players
-    players = await client.team.players.get_team_players(TEAM_ID)
-    print(f"\n=== Team players ===")
-    if players.players:
-        for i, player_item in enumerate(players.players, 1):
-            player = player_item.player
-            print(f"{i:2d}. {player.name} | {player.position or '-'} | #{player.jerseyNumber or '-'}")
-    # Last events
-    last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
-    print(f"\n=== Last events ===")
-    for event in last_events.events:
-        tournament_name = event.tournament.name if event.tournament and event.tournament.name else "-"
-        print(f"Event id: {event.id}, tournament: {tournament_name}, date: {event.startTimestamp}")
-    # Performance
-    perf = await client.team.performance.get_team_performance(TEAM_ID)
-    print(f"\n=== Performance ===")
-    if perf.events:
-        for i, event in enumerate(perf.events[:5], 1):
-            home = event.homeTeam.name if event.homeTeam else '-'
-            away = event.awayTeam.name if event.awayTeam else '-'
-            print(f"{i:2d}. {home} vs {away}")
-            if event.homeScore and event.awayScore:
-                print(f"     Score: {event.homeScore.current or 0} - {event.awayScore.current or 0}")
-    # Rankings
-    rankings = await client.team.rankings.get_team_rankings(TEAM_ID)
-    print(f"\n=== Rankings ===")
-    if rankings.rankings:
-        for r in rankings.rankings:
-            print(f"{r.rowName or '-'}: {r.ranking} place, {r.points} pts, tournament: {r.currentTournamentName}")
-    # Transfers
-    transfers = await client.team.transfers.get_team_transfers(TEAM_ID)
-    print(f"\n=== Transfers in ===")
-    if transfers.transfersIn:
-        for t in transfers.transfersIn:
-            print(f"{t.player.name if t.player else '-'} from {t.fromTeamName or '-'} for {t.transferFeeDescription or '-'}")
-    print(f"\n=== Transfers out ===")
-    if transfers.transfersOut:
-        for t in transfers.transfersOut:
-            print(f"{t.player.name if t.player else '-'} to {t.toTeamName or '-'} for {t.transferFeeDescription or '-'}")
+    async with SofaScoreClient() as client:
+        # Players
+        players = await client.team.players.get_team_players(TEAM_ID)
+        print(f"\n=== Team players ===")
+        if players.players:
+            for i, player_item in enumerate(players.players, 1):
+                player = player_item.player
+                print(f"{i:2d}. {player.name} | {player.position or '-'} | #{player.jerseyNumber or '-'}")
+        # Last events
+        last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
+        print(f"\n=== Last events ===")
+        for event in last_events.events:
+            tournament_name = event.tournament.name if event.tournament and event.tournament.name else "-"
+            print(f"Event id: {event.id}, tournament: {tournament_name}, date: {event.startTimestamp}")
+        # Performance
+        perf = await client.team.performance.get_team_performance(TEAM_ID)
+        print(f"\n=== Performance ===")
+        if perf.events:
+            for i, event in enumerate(perf.events[:5], 1):
+                home = event.homeTeam.name if event.homeTeam else '-'
+                away = event.awayTeam.name if event.awayTeam else '-'
+                print(f"{i:2d}. {home} vs {away}")
+                if event.homeScore and event.awayScore:
+                    print(f"     Score: {event.homeScore.current or 0} - {event.awayScore.current or 0}")
+        # Rankings
+        rankings = await client.team.rankings.get_team_rankings(TEAM_ID)
+        print(f"\n=== Rankings ===")
+        if rankings.rankings:
+            for r in rankings.rankings:
+                print(f"{r.rowName or '-'}: {r.ranking} place, {r.points} pts, tournament: {r.currentTournamentName}")
+        # Transfers
+        transfers = await client.team.transfers.get_team_transfers(TEAM_ID)
+        print(f"\n=== Transfers in ===")
+        if transfers.transfersIn:
+            for t in transfers.transfersIn:
+                print(f"{t.player.name if t.player else '-'} from {t.fromTeamName or '-'} for {t.transferFeeDescription or '-'}")
+        print(f"\n=== Transfers out ===")
+        if transfers.transfersOut:
+            for t in transfers.transfersOut:
+                print(f"{t.player.name if t.player else '-'} to {t.toTeamName or '-'} for {t.transferFeeDescription or '-'}")
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+### HTTP session configuration
+
+If you encounter 403 (anti-bot challenge) errors, pass browser cookies:
+
+```python
+async with SofaScoreClient(cookies={"your_cookie": "value"}) as client:
+    ...
+```
+
+Or set the `SOFASCORE_COOKIES` environment variable (JSON). Optionally use `SOFASCORE_PROXY` for a proxy.
 
 ## License
 This project is licensed under the MIT License — see the LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -29,50 +29,61 @@ TEAM_ID = 2819  # Можно заменить на нужный ID
 PAGE = 0
 
 async def main():
-    client = SofaScoreClient("http://api.sofascore.com")
-    # Игроки
-    players = await client.team.players.get_team_players(TEAM_ID)
-    print(f"\n=== Игроки команды ===")
-    if players.players:
-        for i, player_item in enumerate(players.players, 1):
-            player = player_item.player
-            print(f"{i:2d}. {player.name} | {player.position or '-'} | №{player.jerseyNumber or '-'}")
-    # Последние события
-    last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
-    print(f"\n=== Последние события ===")
-    for event in last_events.events:
-        tournament_name = event.tournament.name if event.tournament and event.tournament.name else "-"
-        print(f"Event id: {event.id}, турнир: {tournament_name}, дата: {event.startTimestamp}")
-    # Производительность
-    perf = await client.team.performance.get_team_performance(TEAM_ID)
-    print(f"\n=== Производительность ===")
-    if perf.events:
-        for i, event in enumerate(perf.events[:5], 1):
-            home = event.homeTeam.name if event.homeTeam else '-'
-            away = event.awayTeam.name if event.awayTeam else '-'
-            print(f"{i:2d}. {home} vs {away}")
-            if event.homeScore and event.awayScore:
-                print(f"     Счёт: {event.homeScore.current or 0} - {event.awayScore.current or 0}")
-    # Рейтинги
-    rankings = await client.team.rankings.get_team_rankings(TEAM_ID)
-    print(f"\n=== Рейтинги ===")
-    if rankings.rankings:
-        for r in rankings.rankings:
-            print(f"{r.rowName or '-'}: {r.ranking} место, {r.points} очков, турнир: {r.currentTournamentName}")
-    # Трансферы
-    transfers = await client.team.transfers.get_team_transfers(TEAM_ID)
-    print(f"\n=== Входящие трансферы ===")
-    if transfers.transfersIn:
-        for t in transfers.transfersIn:
-            print(f"{t.player.name if t.player else '-'} из {t.fromTeamName or '-'} за {t.transferFeeDescription or '-'}")
-    print(f"\n=== Исходящие трансферы ===")
-    if transfers.transfersOut:
-        for t in transfers.transfersOut:
-            print(f"{t.player.name if t.player else '-'} в {t.toTeamName or '-'} за {t.transferFeeDescription or '-'}")
+    async with SofaScoreClient() as client:
+        # Игроки
+        players = await client.team.players.get_team_players(TEAM_ID)
+        print(f"\n=== Игроки команды ===")
+        if players.players:
+            for i, player_item in enumerate(players.players, 1):
+                player = player_item.player
+                print(f"{i:2d}. {player.name} | {player.position or '-'} | №{player.jerseyNumber or '-'}")
+        # Последние события
+        last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
+        print(f"\n=== Последние события ===")
+        for event in last_events.events:
+            tournament_name = event.tournament.name if event.tournament and event.tournament.name else "-"
+            print(f"Event id: {event.id}, турнир: {tournament_name}, дата: {event.startTimestamp}")
+        # Производительность
+        perf = await client.team.performance.get_team_performance(TEAM_ID)
+        print(f"\n=== Производительность ===")
+        if perf.events:
+            for i, event in enumerate(perf.events[:5], 1):
+                home = event.homeTeam.name if event.homeTeam else '-'
+                away = event.awayTeam.name if event.awayTeam else '-'
+                print(f"{i:2d}. {home} vs {away}")
+                if event.homeScore and event.awayScore:
+                    print(f"     Счёт: {event.homeScore.current or 0} - {event.awayScore.current or 0}")
+        # Рейтинги
+        rankings = await client.team.rankings.get_team_rankings(TEAM_ID)
+        print(f"\n=== Рейтинги ===")
+        if rankings.rankings:
+            for r in rankings.rankings:
+                print(f"{r.rowName or '-'}: {r.ranking} место, {r.points} очков, турнир: {r.currentTournamentName}")
+        # Трансферы
+        transfers = await client.team.transfers.get_team_transfers(TEAM_ID)
+        print(f"\n=== Входящие трансферы ===")
+        if transfers.transfersIn:
+            for t in transfers.transfersIn:
+                print(f"{t.player.name if t.player else '-'} из {t.fromTeamName or '-'} за {t.transferFeeDescription or '-'}")
+        print(f"\n=== Исходящие трансферы ===")
+        if transfers.transfersOut:
+            for t in transfers.transfersOut:
+                print(f"{t.player.name if t.player else '-'} в {t.toTeamName or '-'} за {t.transferFeeDescription or '-'}")
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+### Настройка HTTP-сессии
+
+При ошибках 403 (anti-bot challenge) передайте cookies из браузера:
+
+```python
+async with SofaScoreClient(cookies={"your_cookie": "value"}) as client:
+    ...
+```
+
+Или через переменную окружения `SOFASCORE_COOKIES` (JSON). Опционально: `SOFASCORE_PROXY` для прокси.
 
 ## License
 This project is licensed under the MIT License — see the LICENSE file for details.

--- a/aiosofascore/adapters/http_client.py
+++ b/aiosofascore/adapters/http_client.py
@@ -1,66 +1,114 @@
-from aiohttp import ClientSession, ClientResponse, TCPConnector
-import certifi
-import ssl
+import asyncio
+import json
+import os
+from typing import Any
+
+from aiohttp import ClientSession
 
 from aiosofascore.exception import ResponseParseContentError
 
-__all__ = ['HttpSessionManager']
+__all__ = ["HttpSessionManager", "DEFAULT_BASE_URL", "DEFAULT_HEADERS"]
+
+DEFAULT_BASE_URL = "https://api.sofascore.com"
+DEFAULT_HEADERS = {
+    "accept": "application/json",
+    "accept-language": "ru,en;q=0.9",
+    "cache-control": "no-cache",
+    "user-agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+    ),
+    "referer": "https://www.sofascore.com/",
+    "origin": "https://www.sofascore.com",
+    "accept-encoding": "gzip, deflate, br",
+    "connection": "keep-alive",
+}
+RETRYABLE_STATUS_CODES = {403, 429, 500, 502, 503, 504}
+
+
+def _cookies_from_env() -> dict[str, str]:
+    raw = os.getenv("SOFASCORE_COOKIES")
+    if not raw:
+        return {}
+    return json.loads(raw)
+
 
 class HttpSessionManager:
-    def __init__(self, base_url:str):
-        self.BASE_URL = base_url
-        self.cookies = {}
-    
-    def set_cookies(self, cookies: dict):
-        """Set cookies for requests"""
-        self.cookies.update(cookies)
-    
-    async def __aenter__(self):
-        headers = {
-            'accept': 'application/json',
-            'accept-language': 'ru,en;q=0.9',
-            'cache-control': 'no-cache',
-            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 YaBrowser/25.6.0.0 Safari/537.36',
-            'referer': 'https://www.sofascore.com/',
-            'origin': 'https://www.sofascore.com',
-            'accept-encoding': 'gzip, deflate, br',
-            'connection': 'keep-alive'
-        }
-        
-        # Cookies from browser
-        cookies = {
-            '_ga': 'GA1.1.729489537.1752538361',
-            'FCCDCF': '%5Bnull%2Cnull%2Cnull%2C%5B%22CQUmAQAQUmAQAEsACBRUBzFoAP_gAEPgAA6IKkAB5C5GTSFBYT51KIsEYAAHwBAAIsAgAgYBAwABQJKU4JQCBGAAEAhAhiICkAAAKlSBIAFACBAQAAAAAAAAIAAEIAAQgAAIICAAAAAAAABICAAoAIoAEAAAwDiABAUAkBgMANIISNyQCQAABSCAQgAAEACAAQAAAEhgAAAAIAAAEGgEEIBAWAAAEEEYABlMhAAoIAgAAAAAQAgAQCQBRQACgAAAADQgABAMFRwA8hciJpCgsBwqkEWCEAAL4AgAEWAQAAMAwYAAoElKcEIBCjAAAAQAABEACAAAESoAkACAAAwAAAAAAAAAEAASAAAIQAAEEBAAABAAAAAgAAAEAEUACAAAYBQAAgKAQIQGAGkAJC5IBIAQApBAIEAACABAAIAAACQwAAAAEAAACCAACEAgLAAACAAIAAymQgAQEAAAAAAAIAQAIBIQogABAAAAABoQAAAEAAA.dngACAAAAAA%22%2C%222~55.70.89.108.135.147.149.184.211.259.272.313.314.358.385.415.442.486.540.621.938.981.1029.1031.1033.1046.1067.1092.1097.1126.1205.1268.1301.1329.1514.1516.1558.1579.1584.1598.1616.1651.1697.1716.1753.1782.1810.1832.1859.1917.1985.1987.2010.2068.2069.2140.2224.2271.2282.2316.2328.2331.2373.2387.2440.2501.2567.2571.2572.2575.2577.2628.2629.2642.2646.2650.2657.2677.2767.2778.2822.2860.2878.2887.2889.2898.2922.2970.3100.3169.3182.3190.3194.3215.3226.3234.3290.3292.3300.3330.3331.4631.10631.14332.28031.29631~dv.%22%2C%2200128800-CAA4-414D-BA10-8A7A7A8F1C8D%22%5D%5D',
-            '__gads': 'ID=1d26fdee75e0a99a:T=1752538364:RT=1752538364:S=ALNI_MaIbn6v5BlT8MeusLQdVebaLAmkXg',
-            '__gpi': 'UID=000011789a38d607:T=1752538364:RT=1752538364:S=ALNI_Mb1Z4-t04ogU6ngSyLAVyw7PYUF4w',
-            '__eoi': 'ID=847c7becb190d20b:T=1752538364:RT=1752538364:S=AA-AfjZW9zgojew7EAiV84GT49Cn',
-            'FCNEC': '%5B%5B%22AKsRol8-lIhFHDzBNFHYUCg4kz_Q-9-jgxZdUr4hycjlum5ptWGdw0nJT7iJM4pGHbXNsGBlSbwjaZw7WLkuFGWtTIF2GJwmL7Zq82_NWXTcALyEfHVnnHwPp4b0pqbNKtjUU_L5pxaTrIR61eJoRXDOQCMF6evyzA%3D%3D%22%5D%5D',
-            'cto_bundle': 'Sb2Hhl9iJTJGWFFjSG1NY1U3bXlCeDVrVk9vJTJGeUY5cllHb25wNnR6ME9oWVZWbFhxWFp5ckdJdGczZFF3cWoxRGxhM1glMkZCQ1dOVUxKa1pXN25HMEptMXREZ3NoakRCTE0lMkJVTEtCajQxMGFHZFdoNjJjdldoJTJCWlNjNkxzVkhyM0ViblRBTnQ',
-            'cto_bidid': 'L2_xZF9UTFZ1cnhDYURLSU1ialU3QiUyRkVMN3NPUUdTVXFiU0ZhaU55bnNCUFVQazklMkJmd3MlMkY2cU84WiUyQkF5JTJGYzJaNGVUWXlKczklMkJNZk9PR3BnUFdCOG96VE85USUzRCUzRA',
-            '_ga_HNQ9P9MGZR': 'GS2.1.s1752538360$o1$g1$t1752538382$j42$l0$h0'
-        }
-        
-        ssl_context = ssl.create_default_context(cafile=certifi.where())
-        self.session = ClientSession(headers=headers, cookies=cookies)
+    """Manages a reusable aiohttp session for SofaScore API requests."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        cookies: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        proxy: str | None = None,
+        max_retries: int = 3,
+        retry_base_delay: float = 1.0,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.cookies = {**_cookies_from_env(), **(cookies or {})}
+        self.headers = {**DEFAULT_HEADERS, **(headers or {})}
+        self.proxy = proxy or os.getenv("SOFASCORE_PROXY")
+        self.max_retries = max_retries
+        self.retry_base_delay = retry_base_delay
+        self._session: ClientSession | None = None
+
+    @property
+    def is_open(self) -> bool:
+        return self._session is not None and not self._session.closed
+
+    async def open(self) -> None:
+        if self.is_open:
+            return
+        self._session = ClientSession(headers=self.headers, cookies=self.cookies)
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    async def __aenter__(self) -> "HttpSessionManager":
+        await self.open()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self.session.close()
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
 
-    async def get(self, path: str, params: dict = None) -> ClientResponse:
+    def set_cookies(self, cookies: dict[str, str]) -> None:
+        """Update cookies for subsequent requests."""
+        self.cookies.update(cookies)
+        if self._session:
+            self._session.cookie_jar.update_cookies(cookies)
+
+    async def get(self, path: str, params: dict | None = None) -> Any:
         """
-        Executes an HTTP GET request to the given API path.
+        Execute an HTTP GET request and return parsed JSON.
 
-        Args:
-            path (str): The API path to request.
-            params (dict, optional): Query parameters for the request.
-
-        Returns:
-            ClientResponse: The response from the API.
+        Opens the session lazily on first use. Retries transient errors
+        (403 challenge, 429 rate limit, 5xx) with exponential backoff.
         """
-        if params is None:
-            params = {}
-        result = await self.session.get(self.BASE_URL + path, params=params, allow_redirects=False)
-        if result.ok:
-            return await result.json()
-        raise ResponseParseContentError(result,path)
+        if not self.is_open:
+            await self.open()
+
+        params = params or {}
+        url = f"{self.base_url}{path}"
+
+        for attempt in range(self.max_retries + 1):
+            assert self._session is not None
+            async with self._session.get(
+                url, params=params, allow_redirects=False, proxy=self.proxy
+            ) as response:
+                if response.ok:
+                    return await response.json()
+
+                if (
+                    response.status in RETRYABLE_STATUS_CODES
+                    and attempt < self.max_retries
+                ):
+                    delay = self.retry_base_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+                    continue
+
+                raise ResponseParseContentError(response, path)
+
+        raise RuntimeError("Unexpected retry loop exit")

--- a/aiosofascore/api/soccer/services/search/repo.py
+++ b/aiosofascore/api/soccer/services/search/repo.py
@@ -1,13 +1,11 @@
-from pprint import pprint
 from typing import Literal
 
 from aiosofascore.adapters.http_client import HttpSessionManager
 from aiosofascore.api.soccer.services.search.models import SearchEntityResult
-from aiosofascore.exception import ResponseParseContentError
 
 
 class SearchResult:
-    def __init__(self,query: str, http: "HttpSessionManager"):
+    def __init__(self, query: str, http: "HttpSessionManager"):
         self.query = query
         self.page = -1
         self.http = http
@@ -17,29 +15,27 @@ class SearchResult:
         if self.page > 50:
             return []
         params = {
-            'q': self.query,
-            'page': self.page,
+            "q": self.query,
+            "page": self.page,
         }
-        async with self.http:
-            try:
-                resp = await self.http.get('/v1/search/all', params=params)
-                return [SearchEntityResult(**e) for e in resp['results']]
-            except ResponseParseContentError as e:
-                print(await e.async_str())
+        resp = await self.http.get("/v1/search/all", params=params)
+        return [SearchEntityResult(**e) for e in resp["results"]]
+
 
 class SearchRepository:
     def __init__(self, http: "HttpSessionManager"):
         self.http = http
 
-    async def search(self, query: str,type:Literal["team", "player", "event", "manager"]|None=None):
+    async def search(
+        self,
+        query: str,
+        type: Literal["team", "player", "event", "manager"] | None = None,
+    ):
         result = SearchResult(query, self.http)
         while True:
             items = await result.get_next_page()
             if not items:
                 break
             for item in items:
-                if not type:
+                if not type or item.type == type:
                     yield item
-                else:
-                    if item.type == type:
-                        yield item

--- a/aiosofascore/api/soccer/services/team/base.py
+++ b/aiosofascore/api/soccer/services/team/base.py
@@ -1,16 +1,10 @@
-from aiosofascore.adapters.http_client import HttpSessionManager
-from aiosofascore.exception import ResponseParseContentError
-
 class BaseRepository:
     def __init__(self, http: "HttpSessionManager"):
         self.http = http
 
     async def _get(self, url: str, model_cls, params: dict = None):
-        async with self.http:
-            try:
-                resp = await self.http.get(url, params=params)
-                data = resp if isinstance(resp, dict) else await resp.json()
-                return model_cls(**data)
-            except ResponseParseContentError as e:
-                print(await e.async_str())
-                raise 
+        resp = await self.http.get(url, params=params)
+        return model_cls(**resp)
+
+    async def _get_json(self, url: str, params: dict = None) -> dict:
+        return await self.http.get(url, params=params)

--- a/aiosofascore/api/soccer/services/team/repo.py
+++ b/aiosofascore/api/soccer/services/team/repo.py
@@ -1,7 +1,5 @@
-from aiosofascore.adapters.http_client import HttpSessionManager
 from aiosofascore.api.soccer.services.team.models import TeamPerformanceResponse, TeamLastEventsResponse, TeamPlayersResponse, TeamRankingsResponse, TeamTransfersResponse
 from aiosofascore.api.soccer.services.team.common import TeamInfo
-from aiosofascore.exception import ResponseParseContentError
 from aiosofascore.api.soccer.services.team.base import BaseRepository
 
 class TeamPerformanceRepository(BaseRepository):
@@ -12,15 +10,10 @@ class TeamPerformanceRepository(BaseRepository):
 class TeamInfoRepository(BaseRepository):
     async def get_team_info(self, team_id: int) -> TeamInfo:
         url = f"/api/v1/team/{team_id}"
-        data = await self._get_raw(url)
+        data = await self._get_json(url)
         if "team" in data:
             data = data["team"]
         return TeamInfo(**data)
-
-    async def _get_raw(self, url: str, params: dict = None):
-        async with self.http:
-            resp = await self.http.get(url, params=params)
-            return resp if isinstance(resp, dict) else await resp.json()
 
 class TeamLastEventsRepository(BaseRepository):
     async def get_last_events(self, team_id: int, page: int = 0) -> TeamLastEventsResponse:

--- a/aiosofascore/client.py
+++ b/aiosofascore/client.py
@@ -1,40 +1,74 @@
-from aiosofascore.adapters.http_client import HttpSessionManager
+from aiosofascore.adapters.http_client import DEFAULT_BASE_URL, HttpSessionManager
 from aiosofascore.api.soccer.services.team import (
-    TeamPerformanceService, TeamPerformanceRepository,
-    TeamInfoService, TeamInfoRepository,
-    TeamLastEventsService, TeamLastEventsRepository,
-    TeamPlayersService, TeamPlayersRepository,
-    TeamRankingsService, TeamRankingsRepository,
-    TeamTransfersService, TeamTransfersRepository
+    TeamInfoRepository,
+    TeamInfoService,
+    TeamLastEventsRepository,
+    TeamLastEventsService,
+    TeamPerformanceRepository,
+    TeamPerformanceService,
+    TeamPlayersRepository,
+    TeamPlayersService,
+    TeamRankingsRepository,
+    TeamRankingsService,
+    TeamTransfersRepository,
+    TeamTransfersService,
 )
-from aiosofascore.api.soccer.services.search import SearchService, SearchRepository
+from aiosofascore.api.soccer.services.search import SearchRepository, SearchService
+
 
 class SofaScoreTeamServices:
     """Groups all team-related services."""
+
     def __init__(self, http: HttpSessionManager):
-        self.performance: TeamPerformanceService = TeamPerformanceService(TeamPerformanceRepository(http))
-        self.info: TeamInfoService = TeamInfoService(TeamInfoRepository(http))
-        self.last_events: TeamLastEventsService = TeamLastEventsService(TeamLastEventsRepository(http))
-        self.players: TeamPlayersService = TeamPlayersService(TeamPlayersRepository(http))
-        self.rankings: TeamRankingsService = TeamRankingsService(TeamRankingsRepository(http))
-        self.transfers: TeamTransfersService = TeamTransfersService(TeamTransfersRepository(http))
+        self.performance = TeamPerformanceService(TeamPerformanceRepository(http))
+        self.info = TeamInfoService(TeamInfoRepository(http))
+        self.last_events = TeamLastEventsService(TeamLastEventsRepository(http))
+        self.players = TeamPlayersService(TeamPlayersRepository(http))
+        self.rankings = TeamRankingsService(TeamRankingsRepository(http))
+        self.transfers = TeamTransfersService(TeamTransfersRepository(http))
+
 
 class SofaScoreSearchServices:
     """Groups search services."""
+
     def __init__(self, http: HttpSessionManager):
-        self.search: SearchService = SearchService(SearchRepository(http))
+        self.search = SearchService(SearchRepository(http))
+
 
 class SofaScoreClient:
     """
     Main facade for working with the SofaScore API.
-    Example:
-        client = SofaScoreClient(base_url="http://api.sofascore.com")
-        players = await client.team.players.get_team_players(team_id)
-    """
-    def __init__(self, base_url: str):
-        self.http: HttpSessionManager = HttpSessionManager(base_url=base_url)
-        self.team: SofaScoreTeamServices = SofaScoreTeamServices(self.http)
-        self.search: SofaScoreSearchServices = SofaScoreSearchServices(self.http)
 
-class BaseClient:
-    pass
+    Example:
+        async with SofaScoreClient() as client:
+            players = await client.team.players.get_team_players(team_id)
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        cookies: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        proxy: str | None = None,
+        max_retries: int = 3,
+    ):
+        self.http = HttpSessionManager(
+            base_url=base_url or DEFAULT_BASE_URL,
+            cookies=cookies,
+            headers=headers,
+            proxy=proxy,
+            max_retries=max_retries,
+        )
+        self.team = SofaScoreTeamServices(self.http)
+        self.search = SofaScoreSearchServices(self.http)
+
+    async def __aenter__(self) -> "SofaScoreClient":
+        await self.http.open()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.http.close()
+
+    async def close(self) -> None:
+        """Close the underlying HTTP session."""
+        await self.http.close()

--- a/examples/search.py
+++ b/examples/search.py
@@ -2,32 +2,32 @@ import asyncio
 from aiosofascore.client import SofaScoreClient
 
 async def main():
-    client = SofaScoreClient(base_url="http://api.sofascore.com")
-    # Поиск менеджеров по имени Alexander
-    print("=== Менеджеры с именем Alexander ===")
-    async for result in client.search.search.search_entities("Alexander", type="manager"):
-        name = result.entity.name if result.entity and hasattr(result.entity, 'name') else "-"
-        team = result.entity.team.name if result.entity and hasattr(result.entity, 'team') and result.entity.team and hasattr(result.entity.team, 'name') else "-"
-        print(f"Имя: {name}, Тип: {result.type}, Команда: {team}")
-        print('===================')
-    # Поиск матчей Arsenal vs Manchester united
-    print("=== Матчи Arsenal vs Manchester united ===")
-    async for result in client.search.search.search_entities("Arsenal vs Manchester united", type="event"):
-        if result.entity and hasattr(result.entity, 'name'):
-            name = result.entity.name
-        else:
-            name = "-"
-        if result.entity and hasattr(result.entity, 'startTimestamp'):
-            start = result.entity.startTimestamp
-        else:
-            start = "-"
-        status = result.entity.status.type if result.entity and hasattr(result.entity, 'status') and result.entity.status and hasattr(result.entity.status, 'type') else "-"
-        home_score = result.entity.homeScore.display if result.entity and hasattr(result.entity, 'homeScore') and result.entity.homeScore and hasattr(result.entity.homeScore, 'display') else "-"
-        away_score = result.entity.awayScore.display if result.entity and hasattr(result.entity, 'awayScore') and result.entity.awayScore and hasattr(result.entity.awayScore, 'display') else "-"
-        print(f"Матч: {name}, Дата: {start}")
-        if status == "finished":
-            print(f"Счёт: {home_score} - {away_score}")
-        print('===================')
+    async with SofaScoreClient() as client:
+        # Поиск менеджеров по имени Alexander
+        print("=== Менеджеры с именем Alexander ===")
+        async for result in client.search.search.search_entities("Alexander", type="manager"):
+            name = result.entity.name if result.entity and hasattr(result.entity, 'name') else "-"
+            team = result.entity.team.name if result.entity and hasattr(result.entity, 'team') and result.entity.team and hasattr(result.entity.team, 'name') else "-"
+            print(f"Имя: {name}, Тип: {result.type}, Команда: {team}")
+            print('===================')
+        # Поиск матчей Arsenal vs Manchester united
+        print("=== Матчи Arsenal vs Manchester united ===")
+        async for result in client.search.search.search_entities("Arsenal vs Manchester united", type="event"):
+            if result.entity and hasattr(result.entity, 'name'):
+                name = result.entity.name
+            else:
+                name = "-"
+            if result.entity and hasattr(result.entity, 'startTimestamp'):
+                start = result.entity.startTimestamp
+            else:
+                start = "-"
+            status = result.entity.status.type if result.entity and hasattr(result.entity, 'status') and result.entity.status and hasattr(result.entity.status, 'type') else "-"
+            home_score = result.entity.homeScore.display if result.entity and hasattr(result.entity, 'homeScore') and result.entity.homeScore and hasattr(result.entity.homeScore, 'display') else "-"
+            away_score = result.entity.awayScore.display if result.entity and hasattr(result.entity, 'awayScore') and result.entity.awayScore and hasattr(result.entity.awayScore, 'display') else "-"
+            print(f"Матч: {name}, Дата: {start}")
+            if status == "finished":
+                print(f"Счёт: {home_score} - {away_score}")
+            print('===================')
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/team_examples.py
+++ b/examples/team_examples.py
@@ -76,12 +76,12 @@ async def show_transfers(client, team_id):
         print("No outgoing transfers")
 
 async def main():
-    client = SofaScoreClient("http://api.sofascore.com")
-    await show_players(client, TEAM_ID)
-    await show_last_events(client, TEAM_ID, PAGE)
-    await show_performance(client, TEAM_ID)
-    await show_rankings(client, TEAM_ID)
-    await show_transfers(client, TEAM_ID)
+    async with SofaScoreClient() as client:
+        await show_players(client, TEAM_ID)
+        await show_last_events(client, TEAM_ID, PAGE)
+        await show_performance(client, TEAM_ID)
+        await show_rankings(client, TEAM_ID)
+        await show_transfers(client, TEAM_ID)
 
 if __name__ == "__main__":
     asyncio.run(main()) 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+markers =
+    integration: live API tests (run with SOFASCORE_LIVE=1)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="aiosofascore",
-    version="0.1.1.0",
+    version="0.1.2.0",
     description="API client for SofaScore soccer data",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from aiosofascore.client import SofaScoreClient
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    with open(FIXTURES_DIR / name, encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def team_info_response():
+    return load_fixture("team_info.json")
+
+
+@pytest.fixture
+def team_players_response():
+    return load_fixture("team_players.json")
+
+
+@pytest.fixture
+def search_response():
+    return load_fixture("search_results.json")
+
+
+@pytest_asyncio.fixture
+async def mock_client(team_info_response, team_players_response, search_response):
+    """Client with mocked HTTP responses for unit tests."""
+    client = SofaScoreClient(base_url="https://api.sofascore.com")
+
+    async def mock_get(path: str, params: dict | None = None):
+        if path.startswith("/api/v1/team/") and path.endswith("/players"):
+            return team_players_response
+        if path.startswith("/api/v1/team/"):
+            return team_info_response
+        if path == "/v1/search/all":
+            if params and params.get("page", 0) > 0:
+                return {"results": []}
+            return search_response
+        raise AssertionError(f"Unexpected API path: {path}")
+
+    client.http.get = AsyncMock(side_effect=mock_get)
+    await client.http.open()
+    yield client
+    await client.close()

--- a/tests/fixtures/search_results.json
+++ b/tests/fixtures/search_results.json
@@ -1,0 +1,34 @@
+{
+  "results": [
+    {
+      "type": "team",
+      "entity": {
+        "id": 2819,
+        "name": "Manchester United",
+        "nameCode": "MUN",
+        "teamColors": {
+          "primary": "#DA020E",
+          "secondary": "#FFE500",
+          "text": "#FFFFFF"
+        }
+      }
+    },
+    {
+      "type": "player",
+      "entity": {
+        "id": 1,
+        "name": "Bruno Fernandes",
+        "shortName": "B. Fernandes",
+        "team": {
+          "id": 2819,
+          "name": "Manchester United",
+          "teamColors": {
+            "primary": "#DA020E",
+            "secondary": "#FFE500",
+            "text": "#FFFFFF"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/team_info.json
+++ b/tests/fixtures/team_info.json
@@ -1,0 +1,26 @@
+{
+  "team": {
+    "id": 2819,
+    "name": "Manchester United",
+    "slug": "manchester-united",
+    "shortName": "Man Utd",
+    "gender": "M",
+    "sport": {"id": 1, "name": "Football", "slug": "football"},
+    "category": {"id": 1, "name": "England", "slug": "england"},
+    "tournament": {"id": 1, "name": "Premier League", "slug": "premier-league"},
+    "primaryUniqueTournament": {"id": 17, "name": "Premier League", "slug": "premier-league"},
+    "userCount": 1000000,
+    "nameCode": "MUN",
+    "national": false,
+    "type": 0,
+    "country": {"alpha2": "EN", "alpha3": "ENG", "name": "England", "slug": "england"},
+    "fullName": "Manchester United",
+    "teamColors": {"primary": "#DA020E", "secondary": "#FFE500", "text": "#FFFFFF"},
+    "manager": null,
+    "venue": null,
+    "disabled": false,
+    "foundationDateTimestamp": null,
+    "fieldTranslations": null,
+    "timeActive": null
+  }
+}

--- a/tests/fixtures/team_players.json
+++ b/tests/fixtures/team_players.json
@@ -1,0 +1,22 @@
+{
+  "players": [
+    {
+      "player": {
+        "id": 1,
+        "name": "Bruno Fernandes",
+        "shortName": "B. Fernandes",
+        "position": "M",
+        "jerseyNumber": "8"
+      }
+    },
+    {
+      "player": {
+        "id": 2,
+        "name": "Marcus Rashford",
+        "shortName": "M. Rashford",
+        "position": "F",
+        "jerseyNumber": "10"
+      }
+    }
+  ]
+}

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aiosofascore.adapters.http_client import DEFAULT_BASE_URL, HttpSessionManager
+from aiosofascore.exception import ResponseParseContentError
+
+
+@pytest.mark.asyncio
+async def test_default_base_url():
+    http = HttpSessionManager()
+    assert http.base_url == DEFAULT_BASE_URL
+
+
+@pytest.mark.asyncio
+async def test_session_reuse():
+    http = HttpSessionManager()
+    await http.open()
+    session = http._session
+    await http.open()
+    assert http._session is session
+    await http.close()
+    assert not http.is_open
+
+
+@pytest.mark.asyncio
+async def test_context_manager_closes_session():
+    async with HttpSessionManager() as http:
+        assert http.is_open
+    assert not http.is_open
+
+
+@pytest.mark.asyncio
+async def test_lazy_session_open_on_get():
+    http = HttpSessionManager()
+    assert not http.is_open
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json = AsyncMock(return_value={"ok": True})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.get = MagicMock(return_value=mock_response)
+
+    with patch.object(http, "open", wraps=http.open) as open_mock:
+        with patch.object(HttpSessionManager, "_session", mock_session, create=True):
+            http._session = mock_session
+            result = await http.get("/api/v1/test")
+            assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_retry_on_retryable_status():
+    http = HttpSessionManager(max_retries=2, retry_base_delay=0.01)
+
+    call_count = 0
+
+    def make_response(status: int, ok: bool):
+        resp = MagicMock()
+        resp.status = status
+        resp.ok = ok
+        resp.json = AsyncMock(return_value={})
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        return resp
+
+    def mock_get(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            return make_response(429, False)
+        success = make_response(200, True)
+        success.json = AsyncMock(return_value={"data": "ok"})
+        return success
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.get = mock_get
+
+    http._session = mock_session
+    result = await http.get("/api/v1/test")
+    assert result == {"data": "ok"}
+    assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_raises_after_max_retries():
+    http = HttpSessionManager(max_retries=1, retry_base_delay=0.01)
+
+    resp = MagicMock()
+    resp.status = 403
+    resp.ok = False
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.get = MagicMock(return_value=resp)
+
+    http._session = mock_session
+    with pytest.raises(ResponseParseContentError):
+        await http.get("/api/v1/test")
+
+
+@pytest.mark.asyncio
+async def test_set_cookies():
+    http = HttpSessionManager(cookies={"test": "value"})
+    assert http.cookies["test"] == "value"
+    http.set_cookies({"extra": "cookie"})
+    assert http.cookies["extra"] == "cookie"

--- a/tests/test_search_mock.py
+++ b/tests/test_search_mock.py
@@ -1,0 +1,35 @@
+import pytest
+
+from aiosofascore.client import SofaScoreClient
+
+
+@pytest.mark.asyncio
+async def test_search_all_entities(mock_client):
+    results = []
+    async for item in mock_client.search.search.search_entities("Manchester"):
+        results.append(item)
+    assert len(results) == 2
+    assert results[0].type == "team"
+    assert results[1].type == "player"
+
+
+@pytest.mark.asyncio
+async def test_search_teams_only(mock_client):
+    results = []
+    async for item in mock_client.search.search.search_entities(
+        "Manchester", type="team"
+    ):
+        results.append(item)
+    assert len(results) == 1
+    assert results[0].entity.name == "Manchester United"
+
+
+@pytest.mark.asyncio
+async def test_search_players_only(mock_client):
+    results = []
+    async for item in mock_client.search.search.search_entities(
+        "Manchester", type="player"
+    ):
+        results.append(item)
+    assert len(results) == 1
+    assert results[0].entity.name == "Bruno Fernandes"

--- a/tests/test_team_services.py
+++ b/tests/test_team_services.py
@@ -1,33 +1,38 @@
-import pytest
-import asyncio
 import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import pytest
 import pytest_asyncio
+
 from aiosofascore.client import SofaScoreClient
 
 TEAM_ID = 2819
 PAGE = 0
-BASE_URL = "http://api.sofascore.com"
+
+pytestmark = pytest.mark.integration(
+    skipif=not os.getenv("SOFASCORE_LIVE"),
+    reason="Set SOFASCORE_LIVE=1 to run live API tests",
+)
+
 
 @pytest_asyncio.fixture(scope="module")
 async def client():
-    client = SofaScoreClient(BASE_URL)
-    yield client
+    async with SofaScoreClient() as client:
+        yield client
+
 
 @pytest.mark.asyncio
 async def test_get_team_info(client):
     info = await client.team.info.get_team_info(TEAM_ID)
-    print(info)
     assert info.id == TEAM_ID
     assert info.name
     assert info.slug
+
 
 @pytest.mark.asyncio
 async def test_get_team_players(client):
     players = await client.team.players.get_team_players(TEAM_ID)
     assert players.players is None or isinstance(players.players, list)
+
 
 @pytest.mark.asyncio
 async def test_get_team_performance(client):
@@ -35,11 +40,13 @@ async def test_get_team_performance(client):
     assert hasattr(perf, "events")
     assert hasattr(perf, "points")
 
+
 @pytest.mark.asyncio
 async def test_get_team_rankings(client):
     rankings = await client.team.rankings.get_team_rankings(TEAM_ID)
     assert rankings is not None
     assert hasattr(rankings, "rankings")
+
 
 @pytest.mark.asyncio
 async def test_get_team_transfers(client):
@@ -47,8 +54,9 @@ async def test_get_team_transfers(client):
     assert hasattr(transfers, "transfersIn")
     assert hasattr(transfers, "transfersOut")
 
+
 @pytest.mark.asyncio
 async def test_get_team_last_events(client):
     last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
     assert hasattr(last_events, "events")
-    assert hasattr(last_events, "hasNextPage") 
+    assert hasattr(last_events, "hasNextPage")

--- a/tests/test_team_services_mock.py
+++ b/tests/test_team_services_mock.py
@@ -1,0 +1,28 @@
+import pytest
+
+TEAM_ID = 2819
+
+
+@pytest.mark.asyncio
+async def test_get_team_info(mock_client):
+    info = await mock_client.team.info.get_team_info(TEAM_ID)
+    assert info.id == TEAM_ID
+    assert info.name == "Manchester United"
+    assert info.slug == "manchester-united"
+
+
+@pytest.mark.asyncio
+async def test_get_team_players(mock_client):
+    players = await mock_client.team.players.get_team_players(TEAM_ID)
+    assert players.players is not None
+    assert len(players.players) == 2
+    assert players.players[0].player.name == "Bruno Fernandes"
+
+
+@pytest.mark.asyncio
+async def test_client_context_manager():
+    from aiosofascore.client import SofaScoreClient
+
+    async with SofaScoreClient() as client:
+        assert client.http.is_open
+    assert not client.http.is_open


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 0 infrastructure improvements for aiosofascore:

- **HTTP client refactor**: reusable aiohttp session, lazy open, exponential backoff retry on 403/429/5xx
- **Configurable auth**: cookies/headers/proxy via constructor or env vars (`SOFASCORE_COOKIES`, `SOFASCORE_PROXY`); removed hardcoded browser cookies
- **Client lifecycle**: `SofaScoreClient` supports `async with` for proper session cleanup; default base URL is now `https://api.sofascore.com`
- **Repository cleanup**: removed per-request `async with self.http` from all repositories
- **Testing**: 13 mock-based unit tests with JSON fixtures; live API tests marked `@pytest.mark.integration` (opt-in via `SOFASCORE_LIVE=1`)
- **CI**: new GitHub Actions workflow running unit tests on push/PR

## Breaking changes

- `SofaScoreClient("http://api.sofascore.com")` → recommended usage is `async with SofaScoreClient() as client:`
- Hardcoded cookies removed; pass cookies explicitly if needed for anti-bot bypass

## Test plan

- [x] `pytest tests/ -m "not integration" -v` — 13 passed
- [ ] Integration tests: `SOFASCORE_LIVE=1 pytest tests/ -m integration -v` (requires valid cookies)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21f70b23-d570-4561-a59f-1debf34d0b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21f70b23-d570-4561-a59f-1debf34d0b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

