### PR TITLE
v0.2.0: Complete roadmap — all services, tests, docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,41 +2,35 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.11
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-    - name: Install pip
-      run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install black build
 
-    - name: Install dependencies
-      run: pip install -r requirements.txt
+      - name: Run black
+        run: black --check .
 
-    - name : Install black
-      run: pip install black
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/
 
-    - name: Run black
-      run: black .
-
-    - name: Install build
-      run: python -m pip install build
-
-    - name: Build a binary wheel and a source tarball
-      run: python -m build --sdist --wheel --outdir dist/
-
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio black
+
+      - name: Run black
+        run: black --check .
 
       - name: Run unit tests
         run: pytest tests/ -m "not integration" -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## 0.2.0
+
+### Added
+- **Event service**: `get_event`, `get_lineups`, `get_statistics`, `get_incidents`, `get_h2h`, `get_pregame_form`, `get_managers`
+- **Live service**: `get_live_events(sport="football")`
+- **Tournament service**: `get_categories`, `get_unique_tournaments`, `get_seasons`, `get_standings`, `get_standings_by_year`
+- **Player service**: `get_player`, `get_statistics_seasons`, `get_statistics`, `get_transfers`
+- Shared `BaseRepository` with `_get_wrapped` helper
+- 31 unit tests with JSON fixtures
+- Example `examples/all_services.py`
+
+### Changed
+- `SofaScoreClient` exposes `event`, `live`, `tournament`, `player` services
+- CI publish workflow triggers on version tags (`v*`) instead of every push to main
+
+## 0.1.3.0
+
+- Search UX: `client.search` is `SearchService` directly with sugar methods
+- Team statistics: `statistics_seasons`, `statistics`
+- `iter_last_events` async generator
+
+## 0.1.2.0
+
+- HTTP session reuse, retry, configurable cookies/proxy
+- `async with SofaScoreClient()` context manager
+- Mock-based unit tests and CI test workflow
+
+## 0.1.1.0
+
+- Team and search services refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.1
+
+### Changed
+- **Breaking fix:** default API base URL changed from `https://api.sofascore.com` to `https://www.sofascore.com`
+- Search endpoint fixed: `/api/v1/search/all` (was `/v1/search/all`)
+
 ## 0.2.0
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -6,14 +6,16 @@
 
 # Aiosofascore
 
-**Aiosofascore** is an asynchronous Python client for the SofaScore API (football), providing easy access to team, match, search, and statistics data.
+**Aiosofascore** is an asynchronous Python client for the SofaScore API (football), providing access to teams, matches, tournaments, players, and search.
 
 ## Features
 
-- Get team info, last matches, and statistics
-- Search for players, teams, events, managers
-- Asynchronous HTTP client based on aiohttp
-- Convenient SofaScoreClient facade for all services
+- **Team** — info, players, events, rankings, transfers, statistics
+- **Event** — match details, lineups, statistics, incidents, H2H
+- **Live** — live matches
+- **Tournament** — categories, tournaments, seasons, standings
+- **Player** — profile, statistics, transfers
+- **Search** — teams, players, events, managers
 
 ## Installation
 
@@ -23,61 +25,37 @@ pip install aiosofascore
 
 ## Quick Start
 
-### Team example (all main features)
 ```python
 import asyncio
 from aiosofascore.client import SofaScoreClient
 
-TEAM_ID = 2819  # You can change to any team ID
-PAGE = 0
-
 async def main():
     async with SofaScoreClient() as client:
-        # Players
-        players = await client.team.players.get_team_players(TEAM_ID)
-        print(f"\n=== Team players ===")
-        if players.players:
-            for i, player_item in enumerate(players.players, 1):
-                player = player_item.player
-                print(f"{i:2d}. {player.name} | {player.position or '-'} | #{player.jerseyNumber or '-'}")
-        # Last events
-        last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
-        print(f"\n=== Last events ===")
-        for event in last_events.events:
-            tournament_name = event.tournament.name if event.tournament and event.tournament.name else "-"
-            print(f"Event id: {event.id}, tournament: {tournament_name}, date: {event.startTimestamp}")
-        # Performance
-        perf = await client.team.performance.get_team_performance(TEAM_ID)
-        print(f"\n=== Performance ===")
-        if perf.events:
-            for i, event in enumerate(perf.events[:5], 1):
-                home = event.homeTeam.name if event.homeTeam else '-'
-                away = event.awayTeam.name if event.awayTeam else '-'
-                print(f"{i:2d}. {home} vs {away}")
-                if event.homeScore and event.awayScore:
-                    print(f"     Score: {event.homeScore.current or 0} - {event.awayScore.current or 0}")
-        # Rankings
-        rankings = await client.team.rankings.get_team_rankings(TEAM_ID)
-        print(f"\n=== Rankings ===")
-        if rankings.rankings:
-            for r in rankings.rankings:
-                print(f"{r.rowName or '-'}: {r.ranking} place, {r.points} pts, tournament: {r.currentTournamentName}")
-        # Transfers
-        transfers = await client.team.transfers.get_team_transfers(TEAM_ID)
-        print(f"\n=== Transfers in ===")
-        if transfers.transfersIn:
-            for t in transfers.transfersIn:
-                print(f"{t.player.name if t.player else '-'} from {t.fromTeamName or '-'} for {t.transferFeeDescription or '-'}")
-        print(f"\n=== Transfers out ===")
-        if transfers.transfersOut:
-            for t in transfers.transfersOut:
-                print(f"{t.player.name if t.player else '-'} to {t.toTeamName or '-'} for {t.transferFeeDescription or '-'}")
+        info = await client.team.info.get_team_info(2819)
+        live = await client.live.get_live_events()
+        event = await client.event.get_event(11352523)
+        standings = await client.tournament.get_standings(17, 52186)
+        player = await client.player.get_player(12345)
+        async for result in client.search.search_teams("Arsenal"):
+            print(result.entity.name)
 
-if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
 
-### HTTP session configuration
+## API Overview
+
+| Service | Methods |
+|---------|---------|
+| `client.team` | info, players, last_events, performance, rankings, transfers, statistics |
+| `client.event` | get_event, get_lineups, get_statistics, get_incidents, get_h2h, get_pregame_form, get_managers |
+| `client.live` | get_live_events |
+| `client.tournament` | get_categories, get_unique_tournaments, get_seasons, get_standings |
+| `client.player` | get_player, get_statistics_seasons, get_statistics, get_transfers |
+| `client.search` | search_teams, search_players, search_events, search_managers, search_all |
+
+See [CHANGELOG.md](CHANGELOG.md) for version history.
+
+## HTTP Session Configuration
 
 If you encounter 403 (anti-bot challenge) errors, pass browser cookies:
 
@@ -86,10 +64,19 @@ async with SofaScoreClient(cookies={"your_cookie": "value"}) as client:
     ...
 ```
 
-Or set the `SOFASCORE_COOKIES` environment variable (JSON). Optionally use `SOFASCORE_PROXY` for a proxy.
+Or set `SOFASCORE_COOKIES` (JSON). Optionally use `SOFASCORE_PROXY` for a proxy.
+
+## Tests
+
+```bash
+pytest tests/ -m "not integration" -v
+SOFASCORE_LIVE=1 pytest tests/ -m integration
+```
 
 ## License
-This project is licensed under the MIT License — see the LICENSE file for details.
+
+MIT — see [LICENSE](LICENSE).
 
 ## Contact
-If you have any questions or suggestions, feel free to open an issue or contact me via vasilewskij.fil@gmail.com 
+
+Questions and suggestions: GitHub issue or vasilewskij.fil@gmail.com

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@
 
 # Aiosofascore
 
-**Aiosofascore** — асинхронный Python-клиент для SofaScore API (футбол), предоставляющий удобный доступ к данным о командах, матчах, поиску и статистике.
+**Aiosofascore** — асинхронный Python-клиент для SofaScore API (футбол), предоставляющий удобный доступ к данным о командах, матчах, турнирах, игроках и поиску.
 
 ## Возможности
 
-- Получение информации о командах, последних матчах, статистике
-- Поиск игроков, команд, событий, менеджеров
-- Асинхронный HTTP-клиент на базе aiohttp
+- **Team** — информация, игроки, матчи, рейтинги, трансферы, статистика
+- **Event** — детали матча, составы, статистика, инциденты, H2H
+- **Live** — текущие live-матчи
+- **Tournament** — категории, турниры, сезоны, таблицы
+- **Player** — профиль, статистика, трансферы
+- **Search** — поиск команд, игроков, матчей, менеджеров
 
 ## Установка
 
@@ -20,61 +23,57 @@
 pip install aiosofascore
 ```
 
-### Пример работы с командой (все основные возможности)
+## Быстрый старт
+
 ```python
 import asyncio
 from aiosofascore.client import SofaScoreClient
 
-TEAM_ID = 2819  # Можно заменить на нужный ID
-PAGE = 0
-
 async def main():
     async with SofaScoreClient() as client:
-        # Игроки
-        players = await client.team.players.get_team_players(TEAM_ID)
-        print(f"\n=== Игроки команды ===")
-        if players.players:
-            for i, player_item in enumerate(players.players, 1):
-                player = player_item.player
-                print(f"{i:2d}. {player.name} | {player.position or '-'} | №{player.jerseyNumber or '-'}")
-        # Последние события
-        last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
-        print(f"\n=== Последние события ===")
-        for event in last_events.events:
-            tournament_name = event.tournament.name if event.tournament and event.tournament.name else "-"
-            print(f"Event id: {event.id}, турнир: {tournament_name}, дата: {event.startTimestamp}")
-        # Производительность
-        perf = await client.team.performance.get_team_performance(TEAM_ID)
-        print(f"\n=== Производительность ===")
-        if perf.events:
-            for i, event in enumerate(perf.events[:5], 1):
-                home = event.homeTeam.name if event.homeTeam else '-'
-                away = event.awayTeam.name if event.awayTeam else '-'
-                print(f"{i:2d}. {home} vs {away}")
-                if event.homeScore and event.awayScore:
-                    print(f"     Счёт: {event.homeScore.current or 0} - {event.awayScore.current or 0}")
-        # Рейтинги
-        rankings = await client.team.rankings.get_team_rankings(TEAM_ID)
-        print(f"\n=== Рейтинги ===")
-        if rankings.rankings:
-            for r in rankings.rankings:
-                print(f"{r.rowName or '-'}: {r.ranking} место, {r.points} очков, турнир: {r.currentTournamentName}")
-        # Трансферы
-        transfers = await client.team.transfers.get_team_transfers(TEAM_ID)
-        print(f"\n=== Входящие трансферы ===")
-        if transfers.transfersIn:
-            for t in transfers.transfersIn:
-                print(f"{t.player.name if t.player else '-'} из {t.fromTeamName or '-'} за {t.transferFeeDescription or '-'}")
-        print(f"\n=== Исходящие трансферы ===")
-        if transfers.transfersOut:
-            for t in transfers.transfersOut:
-                print(f"{t.player.name if t.player else '-'} в {t.toTeamName or '-'} за {t.transferFeeDescription or '-'}")
+        # Команда
+        info = await client.team.info.get_team_info(2819)
+        print(info.name)
 
-if __name__ == "__main__":
-    asyncio.run(main())
+        # Live-матчи
+        live = await client.live.get_live_events()
+        for e in live.events or []:
+            print(e.homeTeam.name, "vs", e.awayTeam.name)
+
+        # Матч
+        event = await client.event.get_event(11352523)
+        stats = await client.event.get_statistics(11352523)
+
+        # Турнирная таблица
+        standings = await client.tournament.get_standings(17, 52186)
+
+        # Игрок
+        player = await client.player.get_player(12345)
+
+        # Поиск
+        async for result in client.search.search_teams("Arsenal"):
+            print(result.entity.name)
+
+asyncio.run(main())
 ```
 
-### Настройка HTTP-сессии
+## API
+
+| Сервис | Метод | Описание |
+|--------|-------|----------|
+| `client.team.info` | `get_team_info(id)` | Информация о команде |
+| `client.team.players` | `get_team_players(id)` | Состав |
+| `client.team.last_events` | `get_last_events(id, page)` / `iter_last_events(id)` | Последние матчи |
+| `client.team.statistics` | `get_statistics(id, tournament_id, season_id)` | Статистика сезона |
+| `client.event` | `get_event`, `get_lineups`, `get_statistics`, `get_incidents`, `get_h2h` | Матч |
+| `client.live` | `get_live_events()` | Live-матчи |
+| `client.tournament` | `get_categories`, `get_standings`, `get_seasons` | Турниры |
+| `client.player` | `get_player`, `get_statistics`, `get_transfers` | Игрок |
+| `client.search` | `search_teams`, `search_players`, `search_events`, `search_all` | Поиск |
+
+Полный список изменений — в [CHANGELOG.md](CHANGELOG.md).
+
+## Настройка HTTP-сессии
 
 При ошибках 403 (anti-bot challenge) передайте cookies из браузера:
 
@@ -85,8 +84,17 @@ async with SofaScoreClient(cookies={"your_cookie": "value"}) as client:
 
 Или через переменную окружения `SOFASCORE_COOKIES` (JSON). Опционально: `SOFASCORE_PROXY` для прокси.
 
+## Тесты
+
+```bash
+pytest tests/ -m "not integration" -v          # unit-тесты (без сети)
+SOFASCORE_LIVE=1 pytest tests/ -m integration  # live API
+```
+
 ## License
-This project is licensed under the MIT License — see the LICENSE file for details.
+
+MIT — см. [LICENSE](LICENSE).
 
 ## Contact
-If you have any questions or suggestions, feel free to open an issue or contact me via vasilewskij.fil@gmail.com
+
+Вопросы и предложения: issue на GitHub или vasilewskij.fil@gmail.com

--- a/aiosofascore/adapters/http_client.py
+++ b/aiosofascore/adapters/http_client.py
@@ -15,7 +15,7 @@ __all__ = [
     "load_cookies_from_file",
 ]
 
-DEFAULT_BASE_URL = "https://api.sofascore.com"
+DEFAULT_BASE_URL = "https://www.sofascore.com"
 DEFAULT_HEADERS = {
     "accept": "application/json",
     "accept-language": "ru,en;q=0.9",
@@ -113,9 +113,7 @@ class HttpSessionManager:
         self.transport = _resolve_transport(transport)
         self.impersonate = impersonate or os.getenv("SOFASCORE_IMPERSONATE", "chrome")
         self.warmup = (
-            warmup
-            if warmup is not None
-            else os.getenv("SOFASCORE_WARMUP", "1") != "0"
+            warmup if warmup is not None else os.getenv("SOFASCORE_WARMUP", "1") != "0"
         )
         self._session: Any = None
         self._warmed_up = False

--- a/aiosofascore/adapters/http_client.py
+++ b/aiosofascore/adapters/http_client.py
@@ -1,13 +1,19 @@
 import asyncio
 import json
 import os
-from typing import Any
+from typing import Any, Literal
 
 from aiohttp import ClientSession
 
 from aiosofascore.exception import ResponseParseContentError
 
-__all__ = ["HttpSessionManager", "DEFAULT_BASE_URL", "DEFAULT_HEADERS"]
+__all__ = [
+    "HttpSessionManager",
+    "DEFAULT_BASE_URL",
+    "DEFAULT_HEADERS",
+    "parse_cookie_header",
+    "load_cookies_from_file",
+]
 
 DEFAULT_BASE_URL = "https://api.sofascore.com"
 DEFAULT_HEADERS = {
@@ -24,17 +30,67 @@ DEFAULT_HEADERS = {
     "connection": "keep-alive",
 }
 RETRYABLE_STATUS_CODES = {403, 429, 500, 502, 503, 504}
+Transport = Literal["auto", "aiohttp", "curl"]
+
+
+def _curl_available() -> bool:
+    try:
+        import curl_cffi  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def parse_cookie_header(header: str) -> dict[str, str]:
+    """Convert a DevTools Cookie header string to a dict."""
+    cookies: dict[str, str] = {}
+    for part in header.split(";"):
+        part = part.strip()
+        if "=" in part:
+            key, value = part.split("=", 1)
+            cookies[key.strip()] = value.strip()
+    return cookies
+
+
+def load_cookies_from_file(path: str) -> dict[str, str]:
+    """Load cookies from JSON file or a raw Cookie header text file."""
+    with open(path, encoding="utf-8") as file:
+        raw = file.read().strip()
+    if not raw:
+        return {}
+    if raw.startswith("{"):
+        return json.loads(raw)
+    return parse_cookie_header(raw)
 
 
 def _cookies_from_env() -> dict[str, str]:
     raw = os.getenv("SOFASCORE_COOKIES")
-    if not raw:
-        return {}
-    return json.loads(raw)
+    if raw:
+        raw = raw.strip()
+        if raw.startswith("{"):
+            return json.loads(raw)
+        return parse_cookie_header(raw)
+    cookie_file = os.getenv("SOFASCORE_COOKIES_FILE")
+    if cookie_file:
+        return load_cookies_from_file(cookie_file)
+    return {}
+
+
+def _resolve_transport(transport: Transport | None) -> Literal["aiohttp", "curl"]:
+    chosen = transport or os.getenv("SOFASCORE_TRANSPORT", "auto")
+    if chosen == "auto":
+        return "curl" if _curl_available() else "aiohttp"
+    if chosen == "curl" and not _curl_available():
+        raise ImportError(
+            "curl_cffi is required for transport='curl'. "
+            "Install with: pip install 'aiosofascore[curl]'"
+        )
+    return chosen
 
 
 class HttpSessionManager:
-    """Manages a reusable aiohttp session for SofaScore API requests."""
+    """Manages reusable HTTP sessions for SofaScore API requests."""
 
     def __init__(
         self,
@@ -44,6 +100,9 @@ class HttpSessionManager:
         proxy: str | None = None,
         max_retries: int = 3,
         retry_base_delay: float = 1.0,
+        transport: Transport | None = None,
+        impersonate: str | None = None,
+        warmup: bool | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.cookies = {**_cookies_from_env(), **(cookies or {})}
@@ -51,21 +110,48 @@ class HttpSessionManager:
         self.proxy = proxy or os.getenv("SOFASCORE_PROXY")
         self.max_retries = max_retries
         self.retry_base_delay = retry_base_delay
-        self._session: ClientSession | None = None
+        self.transport = _resolve_transport(transport)
+        self.impersonate = impersonate or os.getenv("SOFASCORE_IMPERSONATE", "chrome")
+        self.warmup = (
+            warmup
+            if warmup is not None
+            else os.getenv("SOFASCORE_WARMUP", "1") != "0"
+        )
+        self._session: Any = None
+        self._warmed_up = False
 
     @property
     def is_open(self) -> bool:
-        return self._session is not None and not self._session.closed
+        if self._session is None:
+            return False
+        if self.transport == "aiohttp":
+            return not self._session.closed
+        return True
 
     async def open(self) -> None:
         if self.is_open:
             return
-        self._session = ClientSession(headers=self.headers, cookies=self.cookies)
+        if self.transport == "curl":
+            from curl_cffi.requests import AsyncSession
+
+            self._session = AsyncSession(
+                impersonate=self.impersonate,
+                headers=self.headers,
+                cookies=self.cookies,
+            )
+        else:
+            self._session = ClientSession(headers=self.headers, cookies=self.cookies)
 
     async def close(self) -> None:
-        if self._session and not self._session.closed:
+        if self._session is None:
+            return
+        if self.transport == "aiohttp":
+            if not self._session.closed:
+                await self._session.close()
+        else:
             await self._session.close()
         self._session = None
+        self._warmed_up = False
 
     async def __aenter__(self) -> "HttpSessionManager":
         await self.open()
@@ -75,40 +161,58 @@ class HttpSessionManager:
         await self.close()
 
     def set_cookies(self, cookies: dict[str, str]) -> None:
-        """Update cookies for subsequent requests."""
         self.cookies.update(cookies)
-        if self._session:
+        if self._session and self.transport == "aiohttp":
             self._session.cookie_jar.update_cookies(cookies)
+        elif self._session and self.transport == "curl":
+            self._session.cookies.update(cookies)
+
+    async def _warmup_session(self) -> None:
+        if not self.warmup or self._warmed_up:
+            return
+        if self.transport == "curl":
+            await self._session.get("https://www.sofascore.com/", allow_redirects=True)
+        self._warmed_up = True
 
     async def get(self, path: str, params: dict | None = None) -> Any:
-        """
-        Execute an HTTP GET request and return parsed JSON.
-
-        Opens the session lazily on first use. Retries transient errors
-        (403 challenge, 429 rate limit, 5xx) with exponential backoff.
-        """
         if not self.is_open:
             await self.open()
+        await self._warmup_session()
 
         params = params or {}
         url = f"{self.base_url}{path}"
 
         for attempt in range(self.max_retries + 1):
-            assert self._session is not None
-            async with self._session.get(
-                url, params=params, allow_redirects=False, proxy=self.proxy
-            ) as response:
-                if response.ok:
-                    return await response.json()
-
-                if (
-                    response.status in RETRYABLE_STATUS_CODES
-                    and attempt < self.max_retries
-                ):
-                    delay = self.retry_base_delay * (2**attempt)
-                    await asyncio.sleep(delay)
+            if self.transport == "curl":
+                response = await self._curl_get(url, params)
+                status = response.status_code
+                if 200 <= status < 300:
+                    return response.json()
+                if status in RETRYABLE_STATUS_CODES and attempt < self.max_retries:
+                    await asyncio.sleep(self.retry_base_delay * (2**attempt))
                     continue
-
                 raise ResponseParseContentError(response, path)
+            else:
+                async with self._session.get(
+                    url, params=params, allow_redirects=False, proxy=self.proxy
+                ) as response:
+                    status = response.status
+                    if 200 <= status < 300:
+                        return await response.json()
+                    if status in RETRYABLE_STATUS_CODES and attempt < self.max_retries:
+                        await asyncio.sleep(self.retry_base_delay * (2**attempt))
+                        continue
+                    raise ResponseParseContentError(response, path)
 
         raise RuntimeError("Unexpected retry loop exit")
+
+    async def _curl_get(self, url: str, params: dict) -> Any:
+        assert self._session is not None
+        return await self._session.get(
+            url,
+            params=params,
+            allow_redirects=False,
+            proxy=self.proxy,
+            headers=self.headers,
+            cookies=self.cookies,
+        )

--- a/aiosofascore/api/soccer/services/__init__.py
+++ b/aiosofascore/api/soccer/services/__init__.py
@@ -1,1 +1,8 @@
-from .team import TeamPerformanceService, TeamPerformanceRepository, TeamInfoService, TeamInfoRepository, TeamLastEventsService, TeamLastEventsRepository
+from .team import (
+    TeamPerformanceService,
+    TeamPerformanceRepository,
+    TeamInfoService,
+    TeamInfoRepository,
+    TeamLastEventsService,
+    TeamLastEventsRepository,
+)

--- a/aiosofascore/api/soccer/services/base.py
+++ b/aiosofascore/api/soccer/services/base.py
@@ -1,0 +1,18 @@
+class BaseRepository:
+    def __init__(self, http: "HttpSessionManager"):
+        self.http = http
+
+    async def _get(self, url: str, model_cls, params: dict | None = None):
+        resp = await self.http.get(url, params=params)
+        return model_cls(**resp)
+
+    async def _get_json(self, url: str, params: dict | None = None) -> dict:
+        return await self.http.get(url, params=params)
+
+    async def _get_wrapped(
+        self, url: str, model_cls, key: str, params: dict | None = None
+    ):
+        data = await self._get_json(url, params=params)
+        if key in data:
+            data = data[key]
+        return model_cls(**data)

--- a/aiosofascore/api/soccer/services/event/__init__.py
+++ b/aiosofascore/api/soccer/services/event/__init__.py
@@ -1,0 +1,2 @@
+from .repo import EventRepository
+from .service import EventService

--- a/aiosofascore/api/soccer/services/event/models.py
+++ b/aiosofascore/api/soccer/services/event/models.py
@@ -1,0 +1,108 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from aiosofascore.api.soccer.services.team.common import (
+    Manager,
+    RoundInfo,
+    Score,
+    Season,
+    Status,
+    TeamShortInfo,
+    Tournament,
+)
+
+
+class EventDetail(BaseModel):
+    id: Optional[int] = None
+    slug: Optional[str] = None
+    customId: Optional[str] = None
+    tournament: Optional[Tournament] = None
+    season: Optional[Season] = None
+    roundInfo: Optional[RoundInfo] = None
+    status: Optional[Status] = None
+    winnerCode: Optional[int] = None
+    homeTeam: Optional[TeamShortInfo] = None
+    awayTeam: Optional[TeamShortInfo] = None
+    homeScore: Optional[Score] = None
+    awayScore: Optional[Score] = None
+    startTimestamp: Optional[int] = None
+    venue: Optional[dict] = None
+    referee: Optional[dict] = None
+
+
+class EventLineupsResponse(BaseModel):
+    confirmed: Optional[bool] = None
+    home: Optional[dict] = None
+    away: Optional[dict] = None
+
+
+class EventStatisticsItem(BaseModel):
+    name: Optional[str] = None
+    home: Optional[str | int | float] = None
+    away: Optional[str | int | float] = None
+    homeValue: Optional[float] = None
+    awayValue: Optional[float] = None
+    compareCode: Optional[int] = None
+
+
+class EventStatisticsGroup(BaseModel):
+    groupName: Optional[str] = None
+    statisticsItems: Optional[List[EventStatisticsItem]] = None
+
+
+class EventStatisticsPeriod(BaseModel):
+    period: Optional[str] = None
+    groups: Optional[List[EventStatisticsGroup]] = None
+
+
+class EventStatisticsResponse(BaseModel):
+    statistics: Optional[List[EventStatisticsPeriod]] = None
+
+
+class EventIncident(BaseModel):
+    id: Optional[int] = None
+    time: Optional[int] = None
+    addedTime: Optional[int] = None
+    incidentType: Optional[str] = None
+    player: Optional[dict] = None
+    playerIn: Optional[dict] = None
+    playerOut: Optional[dict] = None
+    isHome: Optional[bool] = None
+    text: Optional[str] = None
+    homeScore: Optional[int] = None
+    awayScore: Optional[int] = None
+
+
+class EventIncidentsResponse(BaseModel):
+    incidents: Optional[List[EventIncident]] = None
+    home: Optional[dict] = None
+    away: Optional[dict] = None
+
+
+class TeamForm(BaseModel):
+    avgRating: Optional[str] = None
+    form: Optional[List[str]] = None
+    position: Optional[int] = None
+    value: Optional[str] = None
+
+
+class PregameFormResponse(BaseModel):
+    homeTeam: Optional[TeamForm] = None
+    awayTeam: Optional[TeamForm] = None
+
+
+class Duel(BaseModel):
+    homeWins: Optional[int] = None
+    awayWins: Optional[int] = None
+    draws: Optional[int] = None
+
+
+class H2HResponse(BaseModel):
+    teamDuel: Optional[Duel] = None
+    managerDuel: Optional[Duel] = None
+
+
+class EventManagersResponse(BaseModel):
+    homeManager: Optional[Manager] = None
+    awayManager: Optional[Manager] = None

--- a/aiosofascore/api/soccer/services/event/repo.py
+++ b/aiosofascore/api/soccer/services/event/repo.py
@@ -1,0 +1,40 @@
+from aiosofascore.api.soccer.services.base import BaseRepository
+from aiosofascore.api.soccer.services.event.models import (
+    EventDetail,
+    EventIncidentsResponse,
+    EventLineupsResponse,
+    EventManagersResponse,
+    EventStatisticsResponse,
+    H2HResponse,
+    PregameFormResponse,
+)
+
+
+class EventRepository(BaseRepository):
+    async def get_event(self, event_id: int) -> EventDetail:
+        url = f"/api/v1/event/{event_id}"
+        return await self._get_wrapped(url, EventDetail, "event")
+
+    async def get_lineups(self, event_id: int) -> EventLineupsResponse:
+        url = f"/api/v1/event/{event_id}/lineups"
+        return await self._get(url, EventLineupsResponse)
+
+    async def get_statistics(self, event_id: int) -> EventStatisticsResponse:
+        url = f"/api/v1/event/{event_id}/statistics"
+        return await self._get(url, EventStatisticsResponse)
+
+    async def get_incidents(self, event_id: int) -> EventIncidentsResponse:
+        url = f"/api/v1/event/{event_id}/incidents"
+        return await self._get(url, EventIncidentsResponse)
+
+    async def get_h2h(self, event_id: int) -> H2HResponse:
+        url = f"/api/v1/event/{event_id}/h2h"
+        return await self._get(url, H2HResponse)
+
+    async def get_pregame_form(self, event_id: int) -> PregameFormResponse:
+        url = f"/api/v1/event/{event_id}/pregame-form"
+        return await self._get(url, PregameFormResponse)
+
+    async def get_managers(self, event_id: int) -> EventManagersResponse:
+        url = f"/api/v1/event/{event_id}/managers"
+        return await self._get(url, EventManagersResponse)

--- a/aiosofascore/api/soccer/services/event/service.py
+++ b/aiosofascore/api/soccer/services/event/service.py
@@ -1,0 +1,36 @@
+from aiosofascore.api.soccer.services.event.models import (
+    EventDetail,
+    EventIncidentsResponse,
+    EventLineupsResponse,
+    EventManagersResponse,
+    EventStatisticsResponse,
+    H2HResponse,
+    PregameFormResponse,
+)
+from aiosofascore.api.soccer.services.event.repo import EventRepository
+
+
+class EventService:
+    def __init__(self, repository: EventRepository):
+        self.repository = repository
+
+    async def get_event(self, event_id: int) -> EventDetail:
+        return await self.repository.get_event(event_id)
+
+    async def get_lineups(self, event_id: int) -> EventLineupsResponse:
+        return await self.repository.get_lineups(event_id)
+
+    async def get_statistics(self, event_id: int) -> EventStatisticsResponse:
+        return await self.repository.get_statistics(event_id)
+
+    async def get_incidents(self, event_id: int) -> EventIncidentsResponse:
+        return await self.repository.get_incidents(event_id)
+
+    async def get_h2h(self, event_id: int) -> H2HResponse:
+        return await self.repository.get_h2h(event_id)
+
+    async def get_pregame_form(self, event_id: int) -> PregameFormResponse:
+        return await self.repository.get_pregame_form(event_id)
+
+    async def get_managers(self, event_id: int) -> EventManagersResponse:
+        return await self.repository.get_managers(event_id)

--- a/aiosofascore/api/soccer/services/live/__init__.py
+++ b/aiosofascore/api/soccer/services/live/__init__.py
@@ -1,0 +1,2 @@
+from .repo import LiveRepository
+from .service import LiveService

--- a/aiosofascore/api/soccer/services/live/models.py
+++ b/aiosofascore/api/soccer/services/live/models.py
@@ -1,0 +1,29 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from aiosofascore.api.soccer.services.team.common import (
+    RoundInfo,
+    Score,
+    Status,
+    TeamShortInfo,
+    Tournament,
+)
+
+
+class LiveEvent(BaseModel):
+    id: Optional[int] = None
+    slug: Optional[str] = None
+    tournament: Optional[Tournament] = None
+    status: Optional[Status] = None
+    homeTeam: Optional[TeamShortInfo] = None
+    awayTeam: Optional[TeamShortInfo] = None
+    homeScore: Optional[Score] = None
+    awayScore: Optional[Score] = None
+    startTimestamp: Optional[int] = None
+    roundInfo: Optional[RoundInfo] = None
+    finalResultOnly: Optional[bool] = None
+
+
+class LiveEventsResponse(BaseModel):
+    events: Optional[List[LiveEvent]] = None

--- a/aiosofascore/api/soccer/services/live/repo.py
+++ b/aiosofascore/api/soccer/services/live/repo.py
@@ -1,0 +1,8 @@
+from aiosofascore.api.soccer.services.base import BaseRepository
+from aiosofascore.api.soccer.services.live.models import LiveEventsResponse
+
+
+class LiveRepository(BaseRepository):
+    async def get_live_events(self, sport: str = "football") -> LiveEventsResponse:
+        url = f"/api/v1/sport/{sport}/events/live"
+        return await self._get(url, LiveEventsResponse)

--- a/aiosofascore/api/soccer/services/live/service.py
+++ b/aiosofascore/api/soccer/services/live/service.py
@@ -1,0 +1,10 @@
+from aiosofascore.api.soccer.services.live.models import LiveEventsResponse
+from aiosofascore.api.soccer.services.live.repo import LiveRepository
+
+
+class LiveService:
+    def __init__(self, repository: LiveRepository):
+        self.repository = repository
+
+    async def get_live_events(self, sport: str = "football") -> LiveEventsResponse:
+        return await self.repository.get_live_events(sport=sport)

--- a/aiosofascore/api/soccer/services/player/__init__.py
+++ b/aiosofascore/api/soccer/services/player/__init__.py
@@ -1,0 +1,2 @@
+from .repo import PlayerRepository
+from .service import PlayerService

--- a/aiosofascore/api/soccer/services/player/models.py
+++ b/aiosofascore/api/soccer/services/player/models.py
@@ -1,0 +1,74 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class PlayerCountry(BaseModel):
+    name: Optional[str] = None
+    alpha2: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class PlayerTeamShort(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    teamColors: Optional[dict] = None
+
+
+class PlayerDetail(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    shortName: Optional[str] = None
+    firstName: Optional[str] = None
+    lastName: Optional[str] = None
+    position: Optional[str] = None
+    jerseyNumber: Optional[str] = None
+    height: Optional[int] = None
+    preferredFoot: Optional[str] = None
+    dateOfBirthTimestamp: Optional[int] = None
+    country: Optional[PlayerCountry] = None
+    team: Optional[PlayerTeamShort] = None
+    userCount: Optional[int] = None
+
+
+class PlayerStatisticsSeason(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    year: Optional[str] = None
+
+
+class PlayerStatisticsUniqueTournament(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class PlayerStatisticsSeasonItem(BaseModel):
+    uniqueTournament: Optional[PlayerStatisticsUniqueTournament] = None
+    seasons: Optional[List[PlayerStatisticsSeason]] = None
+
+
+class PlayerStatisticsSeasonsResponse(BaseModel):
+    uniqueTournamentSeasons: Optional[List[PlayerStatisticsSeasonItem]] = None
+
+
+class PlayerStatisticsResponse(BaseModel):
+    statistics: Optional[dict] = None
+
+
+class PlayerTransfer(BaseModel):
+    id: Optional[int] = None
+    transferDateTimestamp: Optional[int] = None
+    type: Optional[int] = None
+    fromTeamName: Optional[str] = None
+    toTeamName: Optional[str] = None
+    transferFeeDescription: Optional[str] = None
+    player: Optional[dict] = None
+    transferFrom: Optional[dict] = None
+    transferTo: Optional[dict] = None
+
+
+class PlayerTransfersResponse(BaseModel):
+    transferHistory: Optional[List[PlayerTransfer]] = None

--- a/aiosofascore/api/soccer/services/player/repo.py
+++ b/aiosofascore/api/soccer/services/player/repo.py
@@ -1,0 +1,36 @@
+from aiosofascore.api.soccer.services.base import BaseRepository
+from aiosofascore.api.soccer.services.player.models import (
+    PlayerDetail,
+    PlayerStatisticsResponse,
+    PlayerStatisticsSeasonsResponse,
+    PlayerTransfersResponse,
+)
+
+
+class PlayerRepository(BaseRepository):
+    async def get_player(self, player_id: int) -> PlayerDetail:
+        url = f"/api/v1/player/{player_id}"
+        return await self._get_wrapped(url, PlayerDetail, "player")
+
+    async def get_statistics_seasons(
+        self, player_id: int
+    ) -> PlayerStatisticsSeasonsResponse:
+        url = f"/api/v1/player/{player_id}/statistics/seasons"
+        return await self._get(url, PlayerStatisticsSeasonsResponse)
+
+    async def get_statistics(
+        self,
+        player_id: int,
+        tournament_id: int,
+        season_id: int,
+        filter: str = "overall",
+    ) -> PlayerStatisticsResponse:
+        url = (
+            f"/api/v1/player/{player_id}/unique-tournament/{tournament_id}"
+            f"/season/{season_id}/statistics/{filter}"
+        )
+        return await self._get(url, PlayerStatisticsResponse)
+
+    async def get_transfers(self, player_id: int) -> PlayerTransfersResponse:
+        url = f"/api/v1/player/{player_id}/transfer-history"
+        return await self._get(url, PlayerTransfersResponse)

--- a/aiosofascore/api/soccer/services/player/service.py
+++ b/aiosofascore/api/soccer/services/player/service.py
@@ -1,0 +1,34 @@
+from aiosofascore.api.soccer.services.player.models import (
+    PlayerDetail,
+    PlayerStatisticsResponse,
+    PlayerStatisticsSeasonsResponse,
+    PlayerTransfersResponse,
+)
+from aiosofascore.api.soccer.services.player.repo import PlayerRepository
+
+
+class PlayerService:
+    def __init__(self, repository: PlayerRepository):
+        self.repository = repository
+
+    async def get_player(self, player_id: int) -> PlayerDetail:
+        return await self.repository.get_player(player_id)
+
+    async def get_statistics_seasons(
+        self, player_id: int
+    ) -> PlayerStatisticsSeasonsResponse:
+        return await self.repository.get_statistics_seasons(player_id)
+
+    async def get_statistics(
+        self,
+        player_id: int,
+        tournament_id: int,
+        season_id: int,
+        filter: str = "overall",
+    ) -> PlayerStatisticsResponse:
+        return await self.repository.get_statistics(
+            player_id, tournament_id, season_id, filter=filter
+        )
+
+    async def get_transfers(self, player_id: int) -> PlayerTransfersResponse:
+        return await self.repository.get_transfers(player_id)

--- a/aiosofascore/api/soccer/services/search/__init__.py
+++ b/aiosofascore/api/soccer/services/search/__init__.py
@@ -1,4 +1,2 @@
 from .service import SearchService
 from .repo import SearchRepository
-
-

--- a/aiosofascore/api/soccer/services/search/models.py
+++ b/aiosofascore/api/soccer/services/search/models.py
@@ -27,7 +27,7 @@ class Team(BaseModel):
     sport: Optional[Sport] = None
     teamColors: TeamColors
     country: Optional[Country] = None
-    type: Optional[str|int] = None
+    type: Optional[str | int] = None
     gender: Optional[str] = None
 
 
@@ -41,12 +41,14 @@ class Player(BaseModel):
     country: Optional[Country] = None
     sofascoreId: Optional[str] = None
 
+
 class Manager(BaseModel):
     id: int
     name: str
     sport: Optional[Sport] = None
     team: Optional[Team] = None
     country: Optional[Country] = None
+
 
 class TournamentCategory(BaseModel):
     id: int
@@ -89,6 +91,7 @@ class SearchEntityResult(BaseModel):
     model_config = {
         "repr": True,
     }
+
     @model_validator(mode="before")
     @classmethod
     def validate_entity(cls, values: dict) -> dict:

--- a/aiosofascore/api/soccer/services/search/repo.py
+++ b/aiosofascore/api/soccer/services/search/repo.py
@@ -18,7 +18,7 @@ class SearchResult:
             "q": self.query,
             "page": self.page,
         }
-        resp = await self.http.get("/v1/search/all", params=params)
+        resp = await self.http.get("/api/v1/search/all", params=params)
         return [SearchEntityResult(**e) for e in resp["results"]]
 
 

--- a/aiosofascore/api/soccer/services/search/service.py
+++ b/aiosofascore/api/soccer/services/search/service.py
@@ -32,7 +32,9 @@ class SearchService:
         async for item in self.search(query):
             yield item
 
-    async def search_teams(self, query: str) -> AsyncGenerator[SearchEntityResult, None]:
+    async def search_teams(
+        self, query: str
+    ) -> AsyncGenerator[SearchEntityResult, None]:
         async for item in self.search(query, type="team"):
             yield item
 
@@ -42,7 +44,9 @@ class SearchService:
         async for item in self.search(query, type="player"):
             yield item
 
-    async def search_events(self, query: str) -> AsyncGenerator[SearchEntityResult, None]:
+    async def search_events(
+        self, query: str
+    ) -> AsyncGenerator[SearchEntityResult, None]:
         async for item in self.search(query, type="event"):
             yield item
 

--- a/aiosofascore/api/soccer/services/search/service.py
+++ b/aiosofascore/api/soccer/services/search/service.py
@@ -3,15 +3,51 @@ from typing import AsyncGenerator, Literal
 from aiosofascore.api.soccer.services.search.models import SearchEntityResult
 from aiosofascore.api.soccer.services.search.repo import SearchRepository
 
+EntityType = Literal["team", "player", "event", "manager"]
+
 
 class SearchService:
     def __init__(self, repository: SearchRepository):
         self.repository = repository
 
+    async def search(
+        self,
+        query: str,
+        type: EntityType | None = None,
+    ) -> AsyncGenerator[SearchEntityResult, None]:
+        """Search entities by query, optionally filtered by type."""
+        async for item in self.repository.search(query, type=type):
+            yield item
+
     async def search_entities(
         self,
         query: str,
-        type: Literal["team", "player", "event", "manager"] | None = None
+        type: EntityType | None = None,
     ) -> AsyncGenerator[SearchEntityResult, None]:
-        async for item in self.repository.search(query, type=type):
+        """Alias for :meth:`search` (backward compatibility)."""
+        async for item in self.search(query, type=type):
+            yield item
+
+    async def search_all(self, query: str) -> AsyncGenerator[SearchEntityResult, None]:
+        async for item in self.search(query):
+            yield item
+
+    async def search_teams(self, query: str) -> AsyncGenerator[SearchEntityResult, None]:
+        async for item in self.search(query, type="team"):
+            yield item
+
+    async def search_players(
+        self, query: str
+    ) -> AsyncGenerator[SearchEntityResult, None]:
+        async for item in self.search(query, type="player"):
+            yield item
+
+    async def search_events(self, query: str) -> AsyncGenerator[SearchEntityResult, None]:
+        async for item in self.search(query, type="event"):
+            yield item
+
+    async def search_managers(
+        self, query: str
+    ) -> AsyncGenerator[SearchEntityResult, None]:
+        async for item in self.search(query, type="manager"):
             yield item

--- a/aiosofascore/api/soccer/services/team/__init__.py
+++ b/aiosofascore/api/soccer/services/team/__init__.py
@@ -1,2 +1,20 @@
-from .service import TeamPerformanceService, TeamPerformanceRepository, TeamInfoService, TeamLastEventsService, TeamPlayersService, TeamRankingsService, TeamTransfersService
-from .repo import TeamInfoRepository, TeamLastEventsRepository, TeamPlayersRepository, TeamRankingsRepository, TeamTransfersRepository 
+from .service import (
+    TeamInfoService,
+    TeamLastEventsService,
+    TeamPerformanceService,
+    TeamPlayersService,
+    TeamRankingsService,
+    TeamStatisticsSeasonsService,
+    TeamStatisticsService,
+    TeamTransfersService,
+)
+from .repo import (
+    TeamInfoRepository,
+    TeamLastEventsRepository,
+    TeamPerformanceRepository,
+    TeamPlayersRepository,
+    TeamRankingsRepository,
+    TeamStatisticsRepository,
+    TeamStatisticsSeasonsRepository,
+    TeamTransfersRepository,
+)

--- a/aiosofascore/api/soccer/services/team/base.py
+++ b/aiosofascore/api/soccer/services/team/base.py
@@ -1,10 +1,3 @@
-class BaseRepository:
-    def __init__(self, http: "HttpSessionManager"):
-        self.http = http
+from aiosofascore.api.soccer.services.base import BaseRepository
 
-    async def _get(self, url: str, model_cls, params: dict = None):
-        resp = await self.http.get(url, params=params)
-        return model_cls(**resp)
-
-    async def _get_json(self, url: str, params: dict = None) -> dict:
-        return await self.http.get(url, params=params)
+__all__ = ["BaseRepository"]

--- a/aiosofascore/api/soccer/services/team/common.py
+++ b/aiosofascore/api/soccer/services/team/common.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Optional, List, Dict
 
+
 class TeamShortInfo(BaseModel):
     id: int
     name: str
@@ -18,6 +19,7 @@ class TeamShortInfo(BaseModel):
     fieldTranslations: Optional[dict] = None
     country: Optional[dict] = None
 
+
 class TournamentCategory(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
@@ -26,6 +28,7 @@ class TournamentCategory(BaseModel):
     flag: Optional[str] = None
     alpha2: Optional[str] = None
     country: Optional[dict] = None
+
 
 class UniqueTournament(BaseModel):
     id: Optional[int] = None
@@ -41,6 +44,7 @@ class UniqueTournament(BaseModel):
     fieldTranslations: Optional[dict] = None
     country: Optional[dict] = None
 
+
 class Tournament(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
@@ -53,20 +57,24 @@ class Tournament(BaseModel):
     fieldTranslations: Optional[dict] = None
     groupName: Optional[str] = None
 
+
 class Season(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
     year: Optional[str] = None
     editor: Optional[bool] = None
 
+
 class RoundInfo(BaseModel):
     round: Optional[int] = None
     name: Optional[str] = None
+
 
 class Status(BaseModel):
     code: Optional[int] = None
     description: Optional[str] = None
     type: Optional[str] = None
+
 
 class Score(BaseModel):
     current: Optional[int] = None
@@ -74,6 +82,7 @@ class Score(BaseModel):
     period1: Optional[int] = None
     period2: Optional[int] = None
     normaltime: Optional[int] = None
+
 
 class TimeInfo(BaseModel):
     injuryTime1: Optional[int] = None
@@ -83,11 +92,13 @@ class TimeInfo(BaseModel):
     overtimeLength: Optional[int] = None
     totalPeriodCount: Optional[int] = None
 
+
 class Country(BaseModel):
     alpha2: Optional[str]
     alpha3: Optional[str]
     name: str
     slug: str
+
 
 class Manager(BaseModel):
     name: str
@@ -96,12 +107,15 @@ class Manager(BaseModel):
     id: Optional[int]
     country: Optional[Country]
 
+
 class VenueCoordinates(BaseModel):
     latitude: float
     longitude: float
 
+
 class City(BaseModel):
     name: str
+
 
 class Venue(BaseModel):
     city: Optional[City]
@@ -115,10 +129,12 @@ class Venue(BaseModel):
     fieldTranslations: Optional[dict]
     stadium: Optional[dict]
 
+
 class TeamColors(BaseModel):
     primary: str
     secondary: str
     text: str
+
 
 class TeamInfo(BaseModel):
     name: str
@@ -144,11 +160,13 @@ class TeamInfo(BaseModel):
     fieldTranslations: Optional[dict]
     timeActive: Optional[list]
 
+
 class PregameForm(BaseModel):
     avgRating: Optional[str]
     position: Optional[int]
     value: Optional[str]
     form: Optional[List[str]]
+
 
 class Player(BaseModel):
     id: Optional[int] = None
@@ -176,26 +194,32 @@ class Player(BaseModel):
     injury: Optional[dict] = None
     fieldTranslations: Optional[dict] = None
 
+
 class PlayerItem(BaseModel):
     player: Player
 
+
 class CricketSupportStaff(BaseModel):
     pass
+
 
 class TransferTeamShort(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
     slug: Optional[str] = None
 
+
 class TransferPlayerShort(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
     slug: Optional[str] = None
 
+
 class TransferFeeRaw(BaseModel):
     amount: Optional[float] = None
-    currency: Optional[str] = None 
+    currency: Optional[str] = None
+
 
 class Referee(BaseModel):
     id: Optional[int] = None
-    name: Optional[str] = None 
+    name: Optional[str] = None

--- a/aiosofascore/api/soccer/services/team/models.py
+++ b/aiosofascore/api/soccer/services/team/models.py
@@ -1,8 +1,32 @@
 from pydantic import BaseModel, Field
 from typing import Any, Optional, List, Dict
 from .common import (
-    TeamShortInfo, TournamentCategory, UniqueTournament, Tournament, Season, RoundInfo, Status, Score, TimeInfo, Country, Manager, VenueCoordinates, City, Venue, TeamColors, TeamInfo, PregameForm, Player, PlayerItem, CricketSupportStaff, TransferTeamShort, TransferPlayerShort, TransferFeeRaw, Referee
+    TeamShortInfo,
+    TournamentCategory,
+    UniqueTournament,
+    Tournament,
+    Season,
+    RoundInfo,
+    Status,
+    Score,
+    TimeInfo,
+    Country,
+    Manager,
+    VenueCoordinates,
+    City,
+    Venue,
+    TeamColors,
+    TeamInfo,
+    PregameForm,
+    Player,
+    PlayerItem,
+    CricketSupportStaff,
+    TransferTeamShort,
+    TransferPlayerShort,
+    TransferFeeRaw,
+    Referee,
 )
+
 
 class ManOfMatch(BaseModel):
     id: Optional[int] = None
@@ -22,13 +46,16 @@ class ManOfMatch(BaseModel):
     retired: Optional[bool] = None
     deceased: Optional[bool] = None
 
+
 class Periods(BaseModel):
     # Dynamic fields for periods
     pass
 
+
 class TeamSeasonHistoricalForm(BaseModel):
     form: Optional[str] = None
     lastFiveEvents: Optional[List[dict]] = None
+
 
 class PerformanceEvent(BaseModel):
     id: Optional[int] = None
@@ -113,21 +140,25 @@ class PerformanceEvent(BaseModel):
     homeTeamSeasonHistoricalForm: Optional[TeamSeasonHistoricalForm] = None
     awayTeamSeasonHistoricalForm: Optional[TeamSeasonHistoricalForm] = None
 
+
 class TeamPerformanceResponse(BaseModel):
     events: List[PerformanceEvent]
     points: Dict[str, float]
+
 
 class TeamPlayersResponse(BaseModel):
     players: Optional[List[PlayerItem]] = None
     foreignPlayers: Optional[List[PlayerItem]] = None
     nationalPlayers: Optional[List[PlayerItem]] = None
-    supportStaff: Optional[List[CricketSupportStaff]] = None 
+    supportStaff: Optional[List[CricketSupportStaff]] = None
+
 
 class TeamRankingCountry(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
     alpha2: Optional[str] = None
     alpha3: Optional[str] = None
+
 
 class TeamRankingTeam(BaseModel):
     id: Optional[int] = None
@@ -138,10 +169,12 @@ class TeamRankingTeam(BaseModel):
     teamColors: Optional[dict] = None
     nameCode: Optional[str] = None
 
+
 class TeamRankingUniqueTournament(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
     slug: Optional[str] = None
+
 
 class TeamRankingItem(BaseModel):
     id: Optional[int] = None
@@ -169,8 +202,10 @@ class TeamRankingItem(BaseModel):
     totalTeams: Optional[int] = None
     playingTeams: Optional[int] = None
 
+
 class TeamRankingsResponse(BaseModel):
     rankings: Optional[List[TeamRankingItem]] = None
+
 
 # Transfers
 class TransferItem(BaseModel):
@@ -187,9 +222,11 @@ class TransferItem(BaseModel):
     round: Optional[str] = None
     pick: Optional[str] = None
 
+
 class TeamTransfersResponse(BaseModel):
     transfersIn: Optional[List[TransferItem]] = None
-    transfersOut: Optional[List[TransferItem]] = None 
+    transfersOut: Optional[List[TransferItem]] = None
+
 
 class TeamLastEventsResponse(BaseModel):
     events: Optional[List[PerformanceEvent]] = None

--- a/aiosofascore/api/soccer/services/team/models.py
+++ b/aiosofascore/api/soccer/services/team/models.py
@@ -193,4 +193,29 @@ class TeamTransfersResponse(BaseModel):
 
 class TeamLastEventsResponse(BaseModel):
     events: Optional[List[PerformanceEvent]] = None
-    hasNextPage: Optional[bool] = None 
+    hasNextPage: Optional[bool] = None
+
+
+class StatisticsSeason(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    year: Optional[str] = None
+
+
+class StatisticsUniqueTournament(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class UniqueTournamentSeasonItem(BaseModel):
+    uniqueTournament: Optional[StatisticsUniqueTournament] = None
+    seasons: Optional[List[StatisticsSeason]] = None
+
+
+class TeamStatisticsSeasonsResponse(BaseModel):
+    uniqueTournamentSeasons: Optional[List[UniqueTournamentSeasonItem]] = None
+
+
+class TeamStatisticsResponse(BaseModel):
+    statistics: Optional[dict] = None

--- a/aiosofascore/api/soccer/services/team/repo.py
+++ b/aiosofascore/api/soccer/services/team/repo.py
@@ -1,11 +1,21 @@
-from aiosofascore.api.soccer.services.team.models import TeamPerformanceResponse, TeamLastEventsResponse, TeamPlayersResponse, TeamRankingsResponse, TeamTransfersResponse, TeamStatisticsSeasonsResponse, TeamStatisticsResponse
+from aiosofascore.api.soccer.services.team.models import (
+    TeamPerformanceResponse,
+    TeamLastEventsResponse,
+    TeamPlayersResponse,
+    TeamRankingsResponse,
+    TeamTransfersResponse,
+    TeamStatisticsSeasonsResponse,
+    TeamStatisticsResponse,
+)
 from aiosofascore.api.soccer.services.team.common import TeamInfo
 from aiosofascore.api.soccer.services.team.base import BaseRepository
+
 
 class TeamPerformanceRepository(BaseRepository):
     async def get_performance(self, team_id: int) -> TeamPerformanceResponse:
         url = f"/api/v1/team/{team_id}/performance"
         return await self._get(url, TeamPerformanceResponse)
+
 
 class TeamInfoRepository(BaseRepository):
     async def get_team_info(self, team_id: int) -> TeamInfo:
@@ -15,20 +25,26 @@ class TeamInfoRepository(BaseRepository):
             data = data["team"]
         return TeamInfo(**data)
 
+
 class TeamLastEventsRepository(BaseRepository):
-    async def get_last_events(self, team_id: int, page: int = 0) -> TeamLastEventsResponse:
+    async def get_last_events(
+        self, team_id: int, page: int = 0
+    ) -> TeamLastEventsResponse:
         url = f"/api/v1/team/{team_id}/events/last/{page}"
         return await self._get(url, TeamLastEventsResponse)
+
 
 class TeamPlayersRepository(BaseRepository):
     async def get_team_players(self, team_id: int) -> TeamPlayersResponse:
         url = f"/api/v1/team/{team_id}/players"
         return await self._get(url, TeamPlayersResponse)
 
+
 class TeamRankingsRepository(BaseRepository):
     async def get_team_rankings(self, team_id: int) -> TeamRankingsResponse:
         url = f"/api/v1/team/{team_id}/rankings"
         return await self._get(url, TeamRankingsResponse)
+
 
 class TeamTransfersRepository(BaseRepository):
     async def get_team_transfers(self, team_id: int) -> TeamTransfersResponse:
@@ -37,7 +53,9 @@ class TeamTransfersRepository(BaseRepository):
 
 
 class TeamStatisticsSeasonsRepository(BaseRepository):
-    async def get_statistics_seasons(self, team_id: int) -> TeamStatisticsSeasonsResponse:
+    async def get_statistics_seasons(
+        self, team_id: int
+    ) -> TeamStatisticsSeasonsResponse:
         url = f"/api/v1/team/{team_id}/statistics/seasons"
         return await self._get(url, TeamStatisticsSeasonsResponse)
 

--- a/aiosofascore/api/soccer/services/team/repo.py
+++ b/aiosofascore/api/soccer/services/team/repo.py
@@ -1,4 +1,4 @@
-from aiosofascore.api.soccer.services.team.models import TeamPerformanceResponse, TeamLastEventsResponse, TeamPlayersResponse, TeamRankingsResponse, TeamTransfersResponse
+from aiosofascore.api.soccer.services.team.models import TeamPerformanceResponse, TeamLastEventsResponse, TeamPlayersResponse, TeamRankingsResponse, TeamTransfersResponse, TeamStatisticsSeasonsResponse, TeamStatisticsResponse
 from aiosofascore.api.soccer.services.team.common import TeamInfo
 from aiosofascore.api.soccer.services.team.base import BaseRepository
 
@@ -33,4 +33,25 @@ class TeamRankingsRepository(BaseRepository):
 class TeamTransfersRepository(BaseRepository):
     async def get_team_transfers(self, team_id: int) -> TeamTransfersResponse:
         url = f"/api/v1/team/{team_id}/transfers"
-        return await self._get(url, TeamTransfersResponse) 
+        return await self._get(url, TeamTransfersResponse)
+
+
+class TeamStatisticsSeasonsRepository(BaseRepository):
+    async def get_statistics_seasons(self, team_id: int) -> TeamStatisticsSeasonsResponse:
+        url = f"/api/v1/team/{team_id}/statistics/seasons"
+        return await self._get(url, TeamStatisticsSeasonsResponse)
+
+
+class TeamStatisticsRepository(BaseRepository):
+    async def get_statistics(
+        self,
+        team_id: int,
+        tournament_id: int,
+        season_id: int,
+        filter: str = "overall",
+    ) -> TeamStatisticsResponse:
+        url = (
+            f"/api/v1/team/{team_id}/unique-tournament/{tournament_id}"
+            f"/season/{season_id}/statistics/{filter}"
+        )
+        return await self._get(url, TeamStatisticsResponse)

--- a/aiosofascore/api/soccer/services/team/service.py
+++ b/aiosofascore/api/soccer/services/team/service.py
@@ -1,62 +1,129 @@
-from aiosofascore.api.soccer.services.team.repo import TeamPerformanceRepository
-from aiosofascore.api.soccer.services.team.models import TeamPerformanceResponse
+from typing import AsyncGenerator
+
 from aiosofascore.api.soccer.services.team.common import TeamInfo
-from aiosofascore.api.soccer.services.team.repo import TeamInfoRepository
-from aiosofascore.api.soccer.services.team.models import TeamLastEventsResponse
-from aiosofascore.api.soccer.services.team.repo import TeamLastEventsRepository
-from aiosofascore.api.soccer.services.team.repo import TeamPlayersRepository, TeamRankingsRepository, TeamTransfersRepository
-from aiosofascore.api.soccer.services.team.models import TeamPlayersResponse, TeamRankingsResponse, TeamTransfersResponse
+from aiosofascore.api.soccer.services.team.models import (
+    PerformanceEvent,
+    TeamLastEventsResponse,
+    TeamPerformanceResponse,
+    TeamPlayersResponse,
+    TeamRankingsResponse,
+    TeamStatisticsResponse,
+    TeamStatisticsSeasonsResponse,
+    TeamTransfersResponse,
+)
+from aiosofascore.api.soccer.services.team.repo import (
+    TeamInfoRepository,
+    TeamLastEventsRepository,
+    TeamPerformanceRepository,
+    TeamPlayersRepository,
+    TeamRankingsRepository,
+    TeamStatisticsRepository,
+    TeamStatisticsSeasonsRepository,
+    TeamTransfersRepository,
+)
+
 
 class TeamPerformanceService:
     """Service for getting team performance."""
+
     def __init__(self, repository: TeamPerformanceRepository):
         self.repository = repository
 
     async def get_team_performance(self, team_id: int) -> TeamPerformanceResponse:
-        """Get team performance."""
         return await self.repository.get_performance(team_id)
+
 
 class TeamInfoService:
     """Service for getting team info."""
+
     def __init__(self, repository: TeamInfoRepository):
         self.repository = repository
 
     async def get_team_info(self, team_id: int) -> TeamInfo:
-        """Get team info."""
         return await self.repository.get_team_info(team_id)
 
+
 class TeamLastEventsService:
-    """Сервис для получения последних событий команды."""
+    """Service for getting team last events."""
+
     def __init__(self, repository: TeamLastEventsRepository):
         self.repository = repository
 
-    async def get_last_events(self, team_id: int, page: int = 0) -> TeamLastEventsResponse:
-        """Получить последние события команды."""
+    async def get_last_events(
+        self, team_id: int, page: int = 0
+    ) -> TeamLastEventsResponse:
         return await self.repository.get_last_events(team_id, page=page)
+
+    async def iter_last_events(
+        self, team_id: int
+    ) -> AsyncGenerator[PerformanceEvent, None]:
+        """Iterate over all last events, automatically paginating."""
+        page = 0
+        while True:
+            result = await self.repository.get_last_events(team_id, page=page)
+            if result.events:
+                for event in result.events:
+                    yield event
+            if not result.hasNextPage:
+                break
+            page += 1
+
 
 class TeamPlayersService:
     """Service for getting team players."""
+
     def __init__(self, repository: TeamPlayersRepository):
         self.repository = repository
 
     async def get_team_players(self, team_id: int) -> TeamPlayersResponse:
-        """Get list of team players."""
         return await self.repository.get_team_players(team_id)
+
 
 class TeamRankingsService:
     """Service for getting team rankings."""
+
     def __init__(self, repository: TeamRankingsRepository):
         self.repository = repository
 
     async def get_team_rankings(self, team_id: int) -> TeamRankingsResponse:
-        """Get team rankings."""
         return await self.repository.get_team_rankings(team_id)
+
 
 class TeamTransfersService:
     """Service for getting team transfers."""
+
     def __init__(self, repository: TeamTransfersRepository):
         self.repository = repository
 
     async def get_team_transfers(self, team_id: int) -> TeamTransfersResponse:
-        """Get team transfers."""
-        return await self.repository.get_team_transfers(team_id) 
+        return await self.repository.get_team_transfers(team_id)
+
+
+class TeamStatisticsSeasonsService:
+    """Service for listing available statistics seasons for a team."""
+
+    def __init__(self, repository: TeamStatisticsSeasonsRepository):
+        self.repository = repository
+
+    async def get_statistics_seasons(
+        self, team_id: int
+    ) -> TeamStatisticsSeasonsResponse:
+        return await self.repository.get_statistics_seasons(team_id)
+
+
+class TeamStatisticsService:
+    """Service for getting team statistics in a tournament season."""
+
+    def __init__(self, repository: TeamStatisticsRepository):
+        self.repository = repository
+
+    async def get_statistics(
+        self,
+        team_id: int,
+        tournament_id: int,
+        season_id: int,
+        filter: str = "overall",
+    ) -> TeamStatisticsResponse:
+        return await self.repository.get_statistics(
+            team_id, tournament_id, season_id, filter=filter
+        )

--- a/aiosofascore/api/soccer/services/tournament/__init__.py
+++ b/aiosofascore/api/soccer/services/tournament/__init__.py
@@ -1,0 +1,2 @@
+from .repo import TournamentRepository
+from .service import TournamentService

--- a/aiosofascore/api/soccer/services/tournament/models.py
+++ b/aiosofascore/api/soccer/services/tournament/models.py
@@ -1,0 +1,97 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from aiosofascore.api.soccer.services.team.common import UniqueTournament
+
+
+class SportInfo(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class Category(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    flag: Optional[str] = None
+    sport: Optional[SportInfo] = None
+    priority: Optional[int] = None
+
+
+class CategoriesResponse(BaseModel):
+    categories: Optional[List[Category]] = None
+
+
+class UniqueTournamentsResponse(BaseModel):
+    groups: Optional[List[dict]] = None
+
+    @property
+    def unique_tournaments(self) -> List[UniqueTournament]:
+        if not self.groups:
+            return []
+        tournaments = []
+        for group in self.groups:
+            for item in group.get("uniqueTournaments", []):
+                tournaments.append(UniqueTournament(**item))
+        return tournaments
+
+
+class Season(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    year: Optional[str] = None
+    editor: Optional[bool] = None
+
+
+class SeasonsResponse(BaseModel):
+    seasons: Optional[List[Season]] = None
+
+    def get_season_by_year(self, year: str) -> Season | None:
+        if not self.seasons:
+            return None
+        return next((s for s in self.seasons if s.year == year), None)
+
+    def get_current_season(self) -> Season | None:
+        if not self.seasons:
+            return None
+        return self.seasons[0]
+
+
+class StandingsTeam(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    shortName: Optional[str] = None
+    nameCode: Optional[str] = None
+
+
+class StandingsRow(BaseModel):
+    id: Optional[int] = None
+    position: Optional[int] = None
+    points: Optional[int] = None
+    matches: Optional[int] = None
+    wins: Optional[int] = None
+    draws: Optional[int] = None
+    losses: Optional[int] = None
+    scoresFor: Optional[int] = None
+    scoresAgainst: Optional[int] = None
+    team: Optional[StandingsTeam] = None
+
+
+class StandingsResponse(BaseModel):
+    id: Optional[int] = None
+    name: Optional[str] = None
+    rows: Optional[List[StandingsRow]] = None
+    tournament: Optional[dict] = None
+
+
+class StandingsListResponse(BaseModel):
+    standings: Optional[List[StandingsResponse]] = None
+
+    @property
+    def first(self) -> StandingsResponse | None:
+        if not self.standings:
+            return None
+        return self.standings[0]

--- a/aiosofascore/api/soccer/services/tournament/repo.py
+++ b/aiosofascore/api/soccer/services/tournament/repo.py
@@ -1,0 +1,37 @@
+from aiosofascore.api.soccer.services.base import BaseRepository
+from aiosofascore.api.soccer.services.tournament.models import (
+    CategoriesResponse,
+    SeasonsResponse,
+    StandingsListResponse,
+    StandingsResponse,
+    UniqueTournamentsResponse,
+)
+
+
+class TournamentRepository(BaseRepository):
+    async def get_categories(self, sport: str = "football") -> CategoriesResponse:
+        url = f"/api/v1/sport/{sport}/categories"
+        return await self._get(url, CategoriesResponse)
+
+    async def get_unique_tournaments(
+        self, category_id: int
+    ) -> UniqueTournamentsResponse:
+        url = f"/api/v1/category/{category_id}/unique-tournaments"
+        return await self._get(url, UniqueTournamentsResponse)
+
+    async def get_seasons(self, tournament_id: int) -> SeasonsResponse:
+        url = f"/api/v1/unique-tournament/{tournament_id}/seasons"
+        return await self._get(url, SeasonsResponse)
+
+    async def get_standings(
+        self,
+        tournament_id: int,
+        season_id: int,
+        standing_type: str = "total",
+    ) -> StandingsResponse:
+        url = (
+            f"/api/v1/unique-tournament/{tournament_id}"
+            f"/season/{season_id}/standings/{standing_type}"
+        )
+        data = await self._get(url, StandingsListResponse)
+        return data.first or StandingsResponse()

--- a/aiosofascore/api/soccer/services/tournament/service.py
+++ b/aiosofascore/api/soccer/services/tournament/service.py
@@ -1,0 +1,48 @@
+from aiosofascore.api.soccer.services.tournament.models import (
+    CategoriesResponse,
+    SeasonsResponse,
+    StandingsResponse,
+    UniqueTournamentsResponse,
+)
+from aiosofascore.api.soccer.services.tournament.repo import TournamentRepository
+
+
+class TournamentService:
+    def __init__(self, repository: TournamentRepository):
+        self.repository = repository
+
+    async def get_categories(self, sport: str = "football") -> CategoriesResponse:
+        return await self.repository.get_categories(sport=sport)
+
+    async def get_unique_tournaments(
+        self, category_id: int
+    ) -> UniqueTournamentsResponse:
+        return await self.repository.get_unique_tournaments(category_id)
+
+    async def get_seasons(self, tournament_id: int) -> SeasonsResponse:
+        return await self.repository.get_seasons(tournament_id)
+
+    async def get_standings(
+        self,
+        tournament_id: int,
+        season_id: int,
+        standing_type: str = "total",
+    ) -> StandingsResponse:
+        return await self.repository.get_standings(
+            tournament_id, season_id, standing_type=standing_type
+        )
+
+    async def get_standings_by_year(
+        self,
+        tournament_id: int,
+        season_year: str | None = None,
+        standing_type: str = "total",
+    ) -> StandingsResponse:
+        seasons = await self.get_seasons(tournament_id)
+        if season_year:
+            season = seasons.get_season_by_year(season_year)
+        else:
+            season = seasons.get_current_season()
+        if not season or not season.id:
+            return StandingsResponse()
+        return await self.get_standings(tournament_id, season.id, standing_type)

--- a/aiosofascore/client.py
+++ b/aiosofascore/client.py
@@ -1,4 +1,8 @@
 from aiosofascore.adapters.http_client import DEFAULT_BASE_URL, HttpSessionManager
+from aiosofascore.api.soccer.services.event import EventRepository, EventService
+from aiosofascore.api.soccer.services.live import LiveRepository, LiveService
+from aiosofascore.api.soccer.services.player import PlayerRepository, PlayerService
+from aiosofascore.api.soccer.services.search import SearchRepository, SearchService
 from aiosofascore.api.soccer.services.team import (
     TeamInfoRepository,
     TeamInfoService,
@@ -17,7 +21,10 @@ from aiosofascore.api.soccer.services.team import (
     TeamTransfersRepository,
     TeamTransfersService,
 )
-from aiosofascore.api.soccer.services.search import SearchRepository, SearchService
+from aiosofascore.api.soccer.services.tournament import (
+    TournamentRepository,
+    TournamentService,
+)
 
 
 class SofaScoreTeamServices:
@@ -42,7 +49,8 @@ class SofaScoreClient:
 
     Example:
         async with SofaScoreClient() as client:
-            players = await client.team.players.get_team_players(team_id)
+            event = await client.event.get_event(event_id)
+            live = await client.live.get_live_events()
             async for team in client.search.search_teams("Arsenal"):
                 print(team.entity.name)
     """
@@ -64,6 +72,10 @@ class SofaScoreClient:
         )
         self.team = SofaScoreTeamServices(self.http)
         self.search = SearchService(SearchRepository(self.http))
+        self.event = EventService(EventRepository(self.http))
+        self.live = LiveService(LiveRepository(self.http))
+        self.tournament = TournamentService(TournamentRepository(self.http))
+        self.player = PlayerService(PlayerRepository(self.http))
 
     async def __aenter__(self) -> "SofaScoreClient":
         await self.http.open()

--- a/aiosofascore/client.py
+++ b/aiosofascore/client.py
@@ -62,6 +62,9 @@ class SofaScoreClient:
         headers: dict[str, str] | None = None,
         proxy: str | None = None,
         max_retries: int = 3,
+        transport: str | None = None,
+        impersonate: str | None = None,
+        warmup: bool | None = None,
     ):
         self.http = HttpSessionManager(
             base_url=base_url or DEFAULT_BASE_URL,
@@ -69,6 +72,9 @@ class SofaScoreClient:
             headers=headers,
             proxy=proxy,
             max_retries=max_retries,
+            transport=transport,
+            impersonate=impersonate,
+            warmup=warmup,
         )
         self.team = SofaScoreTeamServices(self.http)
         self.search = SearchService(SearchRepository(self.http))

--- a/aiosofascore/client.py
+++ b/aiosofascore/client.py
@@ -10,6 +10,10 @@ from aiosofascore.api.soccer.services.team import (
     TeamPlayersService,
     TeamRankingsRepository,
     TeamRankingsService,
+    TeamStatisticsRepository,
+    TeamStatisticsSeasonsRepository,
+    TeamStatisticsSeasonsService,
+    TeamStatisticsService,
     TeamTransfersRepository,
     TeamTransfersService,
 )
@@ -26,13 +30,10 @@ class SofaScoreTeamServices:
         self.players = TeamPlayersService(TeamPlayersRepository(http))
         self.rankings = TeamRankingsService(TeamRankingsRepository(http))
         self.transfers = TeamTransfersService(TeamTransfersRepository(http))
-
-
-class SofaScoreSearchServices:
-    """Groups search services."""
-
-    def __init__(self, http: HttpSessionManager):
-        self.search = SearchService(SearchRepository(http))
+        self.statistics_seasons = TeamStatisticsSeasonsService(
+            TeamStatisticsSeasonsRepository(http)
+        )
+        self.statistics = TeamStatisticsService(TeamStatisticsRepository(http))
 
 
 class SofaScoreClient:
@@ -42,6 +43,8 @@ class SofaScoreClient:
     Example:
         async with SofaScoreClient() as client:
             players = await client.team.players.get_team_players(team_id)
+            async for team in client.search.search_teams("Arsenal"):
+                print(team.entity.name)
     """
 
     def __init__(
@@ -60,7 +63,7 @@ class SofaScoreClient:
             max_retries=max_retries,
         )
         self.team = SofaScoreTeamServices(self.http)
-        self.search = SofaScoreSearchServices(self.http)
+        self.search = SearchService(SearchRepository(self.http))
 
     async def __aenter__(self) -> "SofaScoreClient":
         await self.http.open()

--- a/aiosofascore/exception.py
+++ b/aiosofascore/exception.py
@@ -1,10 +1,10 @@
-from aiohttp import ClientResponse
+from typing import Any
 
 __all__ = ["ResponseParseContentError"]
 
 
 class ResponseParseContentError(Exception):
-    def __init__(self, response: ClientResponse, path: str):
+    def __init__(self, response: Any, path: str):
         self._response = response
         self._path = path
 
@@ -12,24 +12,47 @@ class ResponseParseContentError(Exception):
     def response(self):
         return self._response
 
+    @property
+    def status(self) -> int:
+        if hasattr(self._response, "status_code"):
+            return int(self._response.status_code)
+        return int(self._response.status)
+
     def __str__(self):
         return (
             f"Response processing error:\n"
-            f"Api call: {self._response.url}\n"
-            f"Headers request: {self._response.request_info}\n"
-            f"Response status: {self._response.status}\n"
-            f"Response: <async - use `await e.async_str()` to see body>\n"
+            f"Api call: {self._path}\n"
+            f"Response status: {self.status}\n"
+            f"Response: <use `await e.async_str()` to see body>\n"
         )
 
     async def async_str(self) -> str:
         try:
-            json_body = await self._response.json()
-        except Exception as e:
-            json_body = f"<failed to parse JSON: {e}>"
+            json_body = await _response_body(self._response)
+        except Exception as exc:
+            json_body = f"<failed to parse body: {exc}>"
 
         return (
             f"Response processing error:\n"
             f"Api call: {self._path}\n"
-            f"Response status: {self._response.status}\n"
+            f"Response status: {self.status}\n"
             f"Response: {json_body}\n"
         )
+
+
+async def _response_body(response: Any) -> Any:
+    if hasattr(response, "json"):
+        try:
+            body = response.json()
+        except TypeError:
+            body = await response.json()
+        else:
+            if hasattr(body, "__await__"):
+                body = await body
+        return body
+    if hasattr(response, "text"):
+        text = response.text
+        if hasattr(text, "__await__"):
+            text = await text
+        return text
+    return str(response)

--- a/aiosofascore/exception.py
+++ b/aiosofascore/exception.py
@@ -1,6 +1,8 @@
 from aiohttp import ClientResponse
 
-__all__ = ['ResponseParseContentError']
+__all__ = ["ResponseParseContentError"]
+
+
 class ResponseParseContentError(Exception):
     def __init__(self, response: ClientResponse, path: str):
         self._response = response

--- a/examples/all_services.py
+++ b/examples/all_services.py
@@ -1,0 +1,47 @@
+"""
+Example usage of event, live, tournament, and player services.
+"""
+
+import asyncio
+
+from aiosofascore.client import SofaScoreClient
+
+EVENT_ID = 11352523
+PLAYER_ID = 12345
+TOURNAMENT_ID = 17
+SEASON_ID = 52186
+
+
+async def main():
+    async with SofaScoreClient() as client:
+        print("=== Live events ===")
+        live = await client.live.get_live_events()
+        for event in (live.events or [])[:3]:
+            home = event.homeTeam.name if event.homeTeam else "-"
+            away = event.awayTeam.name if event.awayTeam else "-"
+            status = event.status.type if event.status else "-"
+            print(f"{home} vs {away} [{status}]")
+
+        print("\n=== Event detail ===")
+        event = await client.event.get_event(EVENT_ID)
+        print(f"{event.homeTeam.name} vs {event.awayTeam.name}")
+
+        print("\n=== Event statistics ===")
+        stats = await client.event.get_statistics(EVENT_ID)
+        if stats.statistics and stats.statistics[0].groups:
+            for item in stats.statistics[0].groups[0].statisticsItems[:3]:
+                print(f"{item.name}: {item.home} - {item.away}")
+
+        print("\n=== Standings ===")
+        standings = await client.tournament.get_standings(TOURNAMENT_ID, SEASON_ID)
+        for row in (standings.rows or [])[:3]:
+            print(f"{row.position}. {row.team.name} — {row.points} pts")
+
+        print("\n=== Player ===")
+        player = await client.player.get_player(PLAYER_ID)
+        team_name = player.team.name if player.team else "-"
+        print(f"{player.name} ({player.position}) — {team_name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/search.py
+++ b/examples/search.py
@@ -1,33 +1,67 @@
 import asyncio
 from aiosofascore.client import SofaScoreClient
 
+
 async def main():
     async with SofaScoreClient() as client:
         # Поиск менеджеров по имени Alexander
         print("=== Менеджеры с именем Alexander ===")
         async for result in client.search.search_managers("Alexander"):
-            name = result.entity.name if result.entity and hasattr(result.entity, 'name') else "-"
-            team = result.entity.team.name if result.entity and hasattr(result.entity, 'team') and result.entity.team and hasattr(result.entity.team, 'name') else "-"
+            name = (
+                result.entity.name
+                if result.entity and hasattr(result.entity, "name")
+                else "-"
+            )
+            team = (
+                result.entity.team.name
+                if result.entity
+                and hasattr(result.entity, "team")
+                and result.entity.team
+                and hasattr(result.entity.team, "name")
+                else "-"
+            )
             print(f"Имя: {name}, Тип: {result.type}, Команда: {team}")
-            print('===================')
+            print("===================")
         # Поиск матчей Arsenal vs Manchester united
         print("=== Матчи Arsenal vs Manchester united ===")
         async for result in client.search.search_events("Arsenal vs Manchester united"):
-            if result.entity and hasattr(result.entity, 'name'):
+            if result.entity and hasattr(result.entity, "name"):
                 name = result.entity.name
             else:
                 name = "-"
-            if result.entity and hasattr(result.entity, 'startTimestamp'):
+            if result.entity and hasattr(result.entity, "startTimestamp"):
                 start = result.entity.startTimestamp
             else:
                 start = "-"
-            status = result.entity.status.type if result.entity and hasattr(result.entity, 'status') and result.entity.status and hasattr(result.entity.status, 'type') else "-"
-            home_score = result.entity.homeScore.display if result.entity and hasattr(result.entity, 'homeScore') and result.entity.homeScore and hasattr(result.entity.homeScore, 'display') else "-"
-            away_score = result.entity.awayScore.display if result.entity and hasattr(result.entity, 'awayScore') and result.entity.awayScore and hasattr(result.entity.awayScore, 'display') else "-"
+            status = (
+                result.entity.status.type
+                if result.entity
+                and hasattr(result.entity, "status")
+                and result.entity.status
+                and hasattr(result.entity.status, "type")
+                else "-"
+            )
+            home_score = (
+                result.entity.homeScore.display
+                if result.entity
+                and hasattr(result.entity, "homeScore")
+                and result.entity.homeScore
+                and hasattr(result.entity.homeScore, "display")
+                else "-"
+            )
+            away_score = (
+                result.entity.awayScore.display
+                if result.entity
+                and hasattr(result.entity, "awayScore")
+                and result.entity.awayScore
+                and hasattr(result.entity.awayScore, "display")
+                else "-"
+            )
             print(f"Матч: {name}, Дата: {start}")
             if status == "finished":
                 print(f"Счёт: {home_score} - {away_score}")
-            print('===================')
+            print("===================")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/search.py
+++ b/examples/search.py
@@ -5,14 +5,14 @@ async def main():
     async with SofaScoreClient() as client:
         # Поиск менеджеров по имени Alexander
         print("=== Менеджеры с именем Alexander ===")
-        async for result in client.search.search.search_entities("Alexander", type="manager"):
+        async for result in client.search.search_managers("Alexander"):
             name = result.entity.name if result.entity and hasattr(result.entity, 'name') else "-"
             team = result.entity.team.name if result.entity and hasattr(result.entity, 'team') and result.entity.team and hasattr(result.entity.team, 'name') else "-"
             print(f"Имя: {name}, Тип: {result.type}, Команда: {team}")
             print('===================')
         # Поиск матчей Arsenal vs Manchester united
         print("=== Матчи Arsenal vs Manchester united ===")
-        async for result in client.search.search.search_entities("Arsenal vs Manchester united", type="event"):
+        async for result in client.search.search_events("Arsenal vs Manchester united"):
             if result.entity and hasattr(result.entity, 'name'):
                 name = result.entity.name
             else:

--- a/examples/team_examples.py
+++ b/examples/team_examples.py
@@ -75,6 +75,28 @@ async def show_transfers(client, team_id):
     else:
         print("No outgoing transfers")
 
+async def show_statistics(client, team_id):
+    print("\n=== Statistics seasons ===")
+    seasons = await client.team.statistics_seasons.get_statistics_seasons(team_id)
+    if not seasons.uniqueTournamentSeasons:
+        print("No statistics seasons found")
+        return
+    item = seasons.uniqueTournamentSeasons[0]
+    tournament = item.uniqueTournament
+    season = item.seasons[0] if item.seasons else None
+    if not tournament or not season:
+        print("No tournament/season data")
+        return
+    print(f"Tournament: {tournament.name}, Season: {season.name}")
+    stats = await client.team.statistics.get_statistics(
+        team_id, tournament.id, season.id
+    )
+    if stats.statistics:
+        for key, value in list(stats.statistics.items())[:5]:
+            print(f"  {key}: {value}")
+    else:
+        print("No statistics data")
+
 async def main():
     async with SofaScoreClient() as client:
         await show_players(client, TEAM_ID)
@@ -82,6 +104,7 @@ async def main():
         await show_performance(client, TEAM_ID)
         await show_rankings(client, TEAM_ID)
         await show_transfers(client, TEAM_ID)
+        await show_statistics(client, TEAM_ID)
 
 if __name__ == "__main__":
     asyncio.run(main()) 

--- a/examples/team_examples.py
+++ b/examples/team_examples.py
@@ -6,11 +6,13 @@ Example usage of SofaScoreClient for working with team endpoints:
 - Rankings
 - Transfers
 """
+
 import asyncio
 from aiosofascore.client import SofaScoreClient
 
 TEAM_ID = 2819
 PAGE = 0
+
 
 async def show_players(client, team_id):
     print("\n=== Team players ===")
@@ -19,17 +21,25 @@ async def show_players(client, team_id):
         print(f"Total players: {len(result.players)}")
         for i, player_item in enumerate(result.players, 1):
             player = player_item.player
-            print(f"{i:2d}. {player.name} | {player.position or '-'} | #{player.jerseyNumber or '-'}")
+            print(
+                f"{i:2d}. {player.name} | {player.position or '-'} | #{player.jerseyNumber or '-'}"
+            )
     else:
         print("No players found")
+
 
 async def show_last_events(client, team_id, page=0):
     print("\n=== Last events ===")
     result = await client.team.last_events.get_last_events(team_id, page)
     print(f"hasNextPage: {result.hasNextPage}")
     for event in result.events:
-        tournament_name = event.tournament.name if event.tournament and event.tournament.name else "-"
-        print(f"Event id: {event.id}, tournament: {tournament_name}, date: {event.startTimestamp}")
+        tournament_name = (
+            event.tournament.name if event.tournament and event.tournament.name else "-"
+        )
+        print(
+            f"Event id: {event.id}, tournament: {tournament_name}, date: {event.startTimestamp}"
+        )
+
 
 async def show_performance(client, team_id):
     print("\n=== Team performance ===")
@@ -37,11 +47,13 @@ async def show_performance(client, team_id):
     if result.events:
         print(f"Total matches: {len(result.events)}")
         for i, event in enumerate(result.events[:5], 1):
-            home = event.homeTeam.name if event.homeTeam else '-'
-            away = event.awayTeam.name if event.awayTeam else '-'
+            home = event.homeTeam.name if event.homeTeam else "-"
+            away = event.awayTeam.name if event.awayTeam else "-"
             print(f"{i:2d}. {home} vs {away}")
             if event.homeScore and event.awayScore:
-                print(f"     Score: {event.homeScore.current or 0} - {event.awayScore.current or 0}")
+                print(
+                    f"     Score: {event.homeScore.current or 0} - {event.awayScore.current or 0}"
+                )
             if event.tournament:
                 print(f"     Tournament: {event.tournament.name}")
     else:
@@ -51,29 +63,38 @@ async def show_performance(client, team_id):
         for pos, pts in result.points.items():
             print(f"  {pos}: {pts}")
 
+
 async def show_rankings(client, team_id):
     print("\n=== Team rankings ===")
     result = await client.team.rankings.get_team_rankings(team_id)
     if result.rankings:
         for r in result.rankings:
-            print(f"{r.rowName or '-'}: {r.ranking} place, {r.points} points, tournament: {r.currentTournamentName}")
+            print(
+                f"{r.rowName or '-'}: {r.ranking} place, {r.points} points, tournament: {r.currentTournamentName}"
+            )
     else:
         print("No ranking data")
+
 
 async def show_transfers(client, team_id):
     print("\n=== Incoming transfers ===")
     result = await client.team.transfers.get_team_transfers(team_id)
     if result.transfersIn:
         for t in result.transfersIn:
-            print(f"{t.player.name if t.player else '-'} from {t.fromTeamName or '-'} for {t.transferFeeDescription or '-'}")
+            print(
+                f"{t.player.name if t.player else '-'} from {t.fromTeamName or '-'} for {t.transferFeeDescription or '-'}"
+            )
     else:
         print("No incoming transfers")
     print("\n=== Outgoing transfers ===")
     if result.transfersOut:
         for t in result.transfersOut:
-            print(f"{t.player.name if t.player else '-'} to {t.toTeamName or '-'} for {t.transferFeeDescription or '-'}")
+            print(
+                f"{t.player.name if t.player else '-'} to {t.toTeamName or '-'} for {t.transferFeeDescription or '-'}"
+            )
     else:
         print("No outgoing transfers")
+
 
 async def show_statistics(client, team_id):
     print("\n=== Statistics seasons ===")
@@ -97,6 +118,7 @@ async def show_statistics(client, team_id):
     else:
         print("No statistics data")
 
+
 async def main():
     async with SofaScoreClient() as client:
         await show_players(client, TEAM_ID)
@@ -106,5 +128,6 @@ async def main():
         await show_transfers(client, TEAM_ID)
         await show_statistics(client, TEAM_ID)
 
+
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(main())

--- a/examples/verify_library.py
+++ b/examples/verify_library.py
@@ -7,7 +7,7 @@
     python examples/verify_library.py
 
 Cookies (обязательно для обхода 403):
-    1. DevTools → Network → запрос к api.sofascore.com → Request Headers → Cookie
+    1. DevTools → Network → запрос к www.sofascore.com/api/... → Request Headers → Cookie
     2. Сохраните в cookies.txt (вся строка Cookie как есть)
     3. export SOFASCORE_COOKIES_FILE=cookies.txt
     python examples/verify_library.py
@@ -80,29 +80,57 @@ async def verify(client: SofaScoreClient) -> list[CheckResult]:
     results: list[CheckResult] = []
 
     section("1. Team — команда")
-    results.append(await run_check("team.info.get_team_info", lambda: _check_team_info(client)))
-    results.append(await run_check("team.players.get_team_players", lambda: _check_team_players(client)))
-    results.append(await run_check("team.last_events.get_last_events", lambda: _check_last_events(client)))
-    results.append(await run_check("team.rankings.get_team_rankings", lambda: _check_rankings(client)))
+    results.append(
+        await run_check("team.info.get_team_info", lambda: _check_team_info(client))
+    )
+    results.append(
+        await run_check(
+            "team.players.get_team_players", lambda: _check_team_players(client)
+        )
+    )
+    results.append(
+        await run_check(
+            "team.last_events.get_last_events", lambda: _check_last_events(client)
+        )
+    )
+    results.append(
+        await run_check(
+            "team.rankings.get_team_rankings", lambda: _check_rankings(client)
+        )
+    )
 
     section("2. Search — поиск")
-    results.append(await run_check("search.search_teams", lambda: _check_search_teams(client)))
+    results.append(
+        await run_check("search.search_teams", lambda: _check_search_teams(client))
+    )
 
     section("3. Live — live-матчи")
     results.append(await run_check("live.get_live_events", lambda: _check_live(client)))
 
     section("4. Tournament — турниры")
-    results.append(await run_check("tournament.get_categories", lambda: _check_categories(client)))
-    results.append(await run_check("tournament.get_standings", lambda: _check_standings(client, TOURNAMENT_ID)))
+    results.append(
+        await run_check("tournament.get_categories", lambda: _check_categories(client))
+    )
+    results.append(
+        await run_check(
+            "tournament.get_standings", lambda: _check_standings(client, TOURNAMENT_ID)
+        )
+    )
 
     section("5. Team statistics — статистика команды")
-    results.append(await run_check("team.statistics", lambda: _check_team_statistics(client)))
+    results.append(
+        await run_check("team.statistics", lambda: _check_team_statistics(client))
+    )
 
     section("6. Event — матч (через поиск)")
-    results.append(await run_check("event via search", lambda: _check_event_via_search(client)))
+    results.append(
+        await run_check("event via search", lambda: _check_event_via_search(client))
+    )
 
     section("7. Player — игрок (через поиск)")
-    results.append(await run_check("player via search", lambda: _check_player_via_search(client)))
+    results.append(
+        await run_check("player via search", lambda: _check_player_via_search(client))
+    )
 
     return results
 
@@ -164,7 +192,9 @@ async def _check_team_statistics(client: SofaScoreClient) -> str:
     season = item.seasons[0] if item.seasons else None
     if not item.uniqueTournament or not season:
         return ok("нет данных")
-    stats = await client.team.statistics.get_statistics(TEAM_ID, item.uniqueTournament.id, season.id)
+    stats = await client.team.statistics.get_statistics(
+        TEAM_ID, item.uniqueTournament.id, season.id
+    )
     return ok(f"полей статистики: {len(stats.statistics or {})}")
 
 
@@ -226,8 +256,8 @@ def print_summary(results: list[CheckResult], transport: str, has_cookies: bool)
             "  SofaScore (Akamai) проверяет TLS-отпечаток клиента.\n"
             "\n  Что сделать:\n"
             "  1. pip install 'aiosofascore[curl]'\n"
-            "  2. Скопируйте Cookie из DevTools для запроса к api.sofascore.com\n"
-            "     (Network → api.sofascore.com → Headers → Cookie — целиком)\n"
+            "  2. Скопируйте Cookie из DevTools для запроса к www.sofascore.com/api/...\n"
+            "     (Network → www.sofascore.com → Headers → Cookie — целиком)\n"
             "  3. Сохраните в cookies.txt и запустите:\n"
             "     export SOFASCORE_COOKIES_FILE=cookies.txt\n"
             "     export SOFASCORE_TRANSPORT=curl\n"
@@ -249,7 +279,9 @@ def print_summary(results: list[CheckResult], transport: str, has_cookies: bool)
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Проверка aiosofascore")
-    parser.add_argument("--cookies-file", help="Файл cookies (JSON или строка Cookie из DevTools)")
+    parser.add_argument(
+        "--cookies-file", help="Файл cookies (JSON или строка Cookie из DevTools)"
+    )
     parser.add_argument("--cookie-header", help="Строка Cookie из DevTools")
     parser.add_argument(
         "--transport",

--- a/examples/verify_library.py
+++ b/examples/verify_library.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Скрипт для ручной проверки работоспособности aiosofascore.
+
+Запуск из корня репозитория:
+    pip install -e .
+    python examples/verify_library.py
+
+Если получаете 403 (anti-bot challenge), задайте cookies из браузера:
+    export SOFASCORE_COOKIES='{"cookie_name": "value"}'
+    python examples/verify_library.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import traceback
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from aiosofascore.client import SofaScoreClient
+from aiosofascore.exception import ResponseParseContentError
+
+# Известные ID для проверки (можно поменять)
+TEAM_ID = 2819          # Manchester United
+TOURNAMENT_ID = 17      # Premier League
+SEARCH_QUERY = "Arsenal"
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+def ok(msg: str) -> str:
+    return msg
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print("=" * 60)
+
+
+async def run_check(name: str, fn: Callable[[], Awaitable[str]]) -> CheckResult:
+    try:
+        detail = await fn()
+        print(f"  ✓ {name}")
+        if detail:
+            print(f"    → {detail}")
+        return CheckResult(name, True, detail)
+    except ResponseParseContentError as exc:
+        detail = await exc.async_str()
+        print(f"  ✗ {name}")
+        print(f"    → HTTP-ошибка API (часто 403 — нужны cookies)")
+        for line in detail.strip().splitlines()[:4]:
+            print(f"    {line}")
+        return CheckResult(name, False, detail)
+    except Exception as exc:
+        print(f"  ✗ {name}")
+        print(f"    → {exc}")
+        return CheckResult(name, False, str(exc))
+
+
+async def verify(client: SofaScoreClient) -> list[CheckResult]:
+    results: list[CheckResult] = []
+
+    section("1. Team — команда")
+    results.append(
+        await run_check(
+            "team.info.get_team_info",
+            lambda: _check_team_info(client),
+        )
+    )
+    results.append(
+        await run_check(
+            "team.players.get_team_players",
+            lambda: _check_team_players(client),
+        )
+    )
+    results.append(
+        await run_check(
+            "team.last_events.get_last_events",
+            lambda: _check_last_events(client),
+        )
+    )
+    results.append(
+        await run_check(
+            "team.rankings.get_team_rankings",
+            lambda: _check_rankings(client),
+        )
+    )
+
+    section("2. Search — поиск")
+    search_result = await run_check(
+        "search.search_teams",
+        lambda: _check_search_teams(client),
+    )
+    results.append(search_result)
+
+    section("3. Live — live-матчи")
+    results.append(
+        await run_check(
+            "live.get_live_events",
+            lambda: _check_live(client),
+        )
+    )
+
+    section("4. Tournament — турниры")
+    results.append(
+        await run_check(
+            "tournament.get_categories",
+            lambda: _check_categories(client),
+        )
+    )
+    results.append(
+        await run_check(
+            "tournament.get_standings",
+            lambda: _check_standings(client, TOURNAMENT_ID),
+        )
+    )
+
+    section("5. Team statistics — статистика команды")
+    results.append(
+        await run_check(
+            "team.statistics_seasons + statistics",
+            lambda: _check_team_statistics(client),
+        )
+    )
+
+    section("6. Event — матч (через поиск)")
+    event_result = await run_check(
+        "search → event.get_event + statistics",
+        lambda: _check_event_via_search(client),
+    )
+    results.append(event_result)
+
+    section("7. Player — игрок (через поиск)")
+    results.append(
+        await run_check(
+            "search → player.get_player",
+            lambda: _check_player_via_search(client),
+        )
+    )
+
+    return results
+
+
+async def _check_team_info(client: SofaScoreClient) -> str:
+    info = await client.team.info.get_team_info(TEAM_ID)
+    return ok(f"{info.name} (id={info.id}, slug={info.slug})")
+
+
+async def _check_team_players(client: SofaScoreClient) -> str:
+    data = await client.team.players.get_team_players(TEAM_ID)
+    count = len(data.players or [])
+    first = data.players[0].player.name if data.players else "—"
+    return ok(f"{count} игроков, первый: {first}")
+
+
+async def _check_last_events(client: SofaScoreClient) -> str:
+    data = await client.team.last_events.get_last_events(TEAM_ID, page=0)
+    count = len(data.events or [])
+    has_next = data.hasNextPage
+    return ok(f"{count} матчей на странице, hasNextPage={has_next}")
+
+
+async def _check_rankings(client: SofaScoreClient) -> str:
+    data = await client.team.rankings.get_team_rankings(TEAM_ID)
+    count = len(data.rankings or [])
+    return ok(f"{count} записей рейтинга")
+
+
+async def _check_search_teams(client: SofaScoreClient) -> str:
+    names = []
+    async for item in client.search.search_teams(SEARCH_QUERY):
+        names.append(item.entity.name)
+        if len(names) >= 3:
+            break
+    return ok(f"найдено: {', '.join(names) or 'ничего'}")
+
+
+async def _check_live(client: SofaScoreClient) -> str:
+    data = await client.live.get_live_events()
+    events = data.events or []
+    if not events:
+        return ok("live-матчей сейчас нет (это нормально)")
+    e = events[0]
+    home = e.homeTeam.name if e.homeTeam else "?"
+    away = e.awayTeam.name if e.awayTeam else "?"
+    status = e.status.type if e.status else "?"
+    return ok(f"{len(events)} live, пример: {home} vs {away} [{status}]")
+
+
+async def _check_categories(client: SofaScoreClient) -> str:
+    data = await client.tournament.get_categories()
+    cats = data.categories or []
+    sample = cats[0].name if cats else "—"
+    return ok(f"{len(cats)} категорий, пример: {sample}")
+
+
+async def _check_standings(client: SofaScoreClient, tournament_id: int) -> str:
+    seasons = await client.tournament.get_seasons(tournament_id)
+    if not seasons.seasons:
+        return ok("сезоны не найдены — пропуск standings")
+    season_id = seasons.seasons[0].id
+
+    data = await client.tournament.get_standings(tournament_id, season_id)
+    rows = data.rows or []
+    if not rows:
+        return ok("таблица пуста")
+    top = rows[0]
+    return ok(
+        f"лидер: {top.team.name} — {top.points} очков ({len(rows)} команд)"
+    )
+
+
+async def _check_team_statistics(client: SofaScoreClient) -> str:
+    seasons = await client.team.statistics_seasons.get_statistics_seasons(TEAM_ID)
+    if not seasons.uniqueTournamentSeasons:
+        return ok("сезоны статистики не найдены")
+    item = seasons.uniqueTournamentSeasons[0]
+    tournament = item.uniqueTournament
+    season = item.seasons[0] if item.seasons else None
+    if not tournament or not season or not season.id:
+        return ok("нет данных турнира/сезона")
+    stats = await client.team.statistics.get_statistics(
+        TEAM_ID, tournament.id, season.id
+    )
+    keys = list((stats.statistics or {}).keys())[:4]
+    return ok(f"{tournament.name} / {season.name}: поля {keys}")
+
+
+async def _check_event_via_search(client: SofaScoreClient) -> str:
+    event_id = None
+    async for item in client.search.search_events(f"{SEARCH_QUERY} vs"):
+        if item.type == "event" and hasattr(item.entity, "id"):
+            event_id = item.entity.id
+            break
+    if not event_id:
+        return ok("матч через поиск не найден — пропуск event API")
+
+    event = await client.event.get_event(event_id)
+    home = event.homeTeam.name if event.homeTeam else "?"
+    away = event.awayTeam.name if event.awayTeam else "?"
+    stats = await client.event.get_statistics(event_id)
+    stat_count = sum(
+        len(g.statisticsItems or [])
+        for s in (stats.statistics or [])
+        for g in (s.groups or [])
+    )
+    return ok(f"id={event_id}: {home} vs {away}, {stat_count} метрик")
+
+
+async def _check_player_via_search(client: SofaScoreClient) -> str:
+    player_id = None
+    async for item in client.search.search_players("Bruno"):
+        if item.type == "player" and hasattr(item.entity, "id"):
+            player_id = item.entity.id
+            break
+    if not player_id:
+        return ok("игрок через поиск не найден — пропуск player API")
+
+    player = await client.player.get_player(player_id)
+    team = player.team.name if player.team else "—"
+    return ok(f"{player.name} (id={player_id}), команда: {team}")
+
+
+def print_summary(results: list[CheckResult]) -> int:
+    section("Итог")
+    passed = sum(1 for r in results if r.ok)
+    failed = len(results) - passed
+    print(f"  Успешно: {passed}/{len(results)}")
+    print(f"  Ошибок:  {failed}/{len(results)}")
+
+    if failed and all("403" in r.detail for r in results if not r.ok):
+        print(
+            "\n  Подсказка: все запросы вернули 403. SofaScore блокирует бота.\n"
+            "  Скопируйте cookies из браузера (DevTools → Network → api.sofascore.com)\n"
+            "  и задайте переменную окружения SOFASCORE_COOKIES:\n"
+            '\n    export SOFASCORE_COOKIES=\'{"имя_cookie": "значение"}\'\n'
+        )
+    elif failed:
+        print("\n  Неудачные проверки:")
+        for r in results:
+            if not r.ok:
+                print(f"    - {r.name}")
+
+    return 0 if failed == 0 else 1
+
+
+async def main() -> int:
+    print("Проверка aiosofascore")
+    print(f"  TEAM_ID={TEAM_ID}, TOURNAMENT_ID={TOURNAMENT_ID}, SEARCH={SEARCH_QUERY!r}")
+
+    try:
+        async with SofaScoreClient() as client:
+            results = await verify(client)
+    except Exception:
+        traceback.print_exc()
+        return 1
+
+    return print_summary(results)
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/verify_library.py
+++ b/examples/verify_library.py
@@ -2,29 +2,40 @@
 """
 Скрипт для ручной проверки работоспособности aiosofascore.
 
-Запуск из корня репозитория:
-    pip install -e .
+Запуск:
+    pip install -e ".[curl]"
     python examples/verify_library.py
 
-Если получаете 403 (anti-bot challenge), задайте cookies из браузера:
-    export SOFASCORE_COOKIES='{"cookie_name": "value"}'
+Cookies (обязательно для обхода 403):
+    1. DevTools → Network → запрос к api.sofascore.com → Request Headers → Cookie
+    2. Сохраните в cookies.txt (вся строка Cookie как есть)
+    3. export SOFASCORE_COOKIES_FILE=cookies.txt
     python examples/verify_library.py
+
+Важно: одних cookies в Python-коде часто недостаточно.
+SofaScore проверяет TLS-отпечаток браузера — нужен transport=curl (curl_cffi).
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import os
 import sys
 import traceback
 from dataclasses import dataclass
 from typing import Awaitable, Callable
 
+from aiosofascore.adapters.http_client import (
+    _curl_available,
+    load_cookies_from_file,
+    parse_cookie_header,
+)
 from aiosofascore.client import SofaScoreClient
 from aiosofascore.exception import ResponseParseContentError
 
-# Известные ID для проверки (можно поменять)
-TEAM_ID = 2819          # Manchester United
-TOURNAMENT_ID = 17      # Premier League
+TEAM_ID = 2819
+TOURNAMENT_ID = 17
 SEARCH_QUERY = "Arsenal"
 
 
@@ -55,8 +66,8 @@ async def run_check(name: str, fn: Callable[[], Awaitable[str]]) -> CheckResult:
     except ResponseParseContentError as exc:
         detail = await exc.async_str()
         print(f"  ✗ {name}")
-        print(f"    → HTTP-ошибка API (часто 403 — нужны cookies)")
-        for line in detail.strip().splitlines()[:4]:
+        print(f"    → HTTP {exc.status}")
+        for line in detail.strip().splitlines()[2:5]:
             print(f"    {line}")
         return CheckResult(name, False, detail)
     except Exception as exc:
@@ -69,109 +80,52 @@ async def verify(client: SofaScoreClient) -> list[CheckResult]:
     results: list[CheckResult] = []
 
     section("1. Team — команда")
-    results.append(
-        await run_check(
-            "team.info.get_team_info",
-            lambda: _check_team_info(client),
-        )
-    )
-    results.append(
-        await run_check(
-            "team.players.get_team_players",
-            lambda: _check_team_players(client),
-        )
-    )
-    results.append(
-        await run_check(
-            "team.last_events.get_last_events",
-            lambda: _check_last_events(client),
-        )
-    )
-    results.append(
-        await run_check(
-            "team.rankings.get_team_rankings",
-            lambda: _check_rankings(client),
-        )
-    )
+    results.append(await run_check("team.info.get_team_info", lambda: _check_team_info(client)))
+    results.append(await run_check("team.players.get_team_players", lambda: _check_team_players(client)))
+    results.append(await run_check("team.last_events.get_last_events", lambda: _check_last_events(client)))
+    results.append(await run_check("team.rankings.get_team_rankings", lambda: _check_rankings(client)))
 
     section("2. Search — поиск")
-    search_result = await run_check(
-        "search.search_teams",
-        lambda: _check_search_teams(client),
-    )
-    results.append(search_result)
+    results.append(await run_check("search.search_teams", lambda: _check_search_teams(client)))
 
     section("3. Live — live-матчи")
-    results.append(
-        await run_check(
-            "live.get_live_events",
-            lambda: _check_live(client),
-        )
-    )
+    results.append(await run_check("live.get_live_events", lambda: _check_live(client)))
 
     section("4. Tournament — турниры")
-    results.append(
-        await run_check(
-            "tournament.get_categories",
-            lambda: _check_categories(client),
-        )
-    )
-    results.append(
-        await run_check(
-            "tournament.get_standings",
-            lambda: _check_standings(client, TOURNAMENT_ID),
-        )
-    )
+    results.append(await run_check("tournament.get_categories", lambda: _check_categories(client)))
+    results.append(await run_check("tournament.get_standings", lambda: _check_standings(client, TOURNAMENT_ID)))
 
     section("5. Team statistics — статистика команды")
-    results.append(
-        await run_check(
-            "team.statistics_seasons + statistics",
-            lambda: _check_team_statistics(client),
-        )
-    )
+    results.append(await run_check("team.statistics", lambda: _check_team_statistics(client)))
 
     section("6. Event — матч (через поиск)")
-    event_result = await run_check(
-        "search → event.get_event + statistics",
-        lambda: _check_event_via_search(client),
-    )
-    results.append(event_result)
+    results.append(await run_check("event via search", lambda: _check_event_via_search(client)))
 
     section("7. Player — игрок (через поиск)")
-    results.append(
-        await run_check(
-            "search → player.get_player",
-            lambda: _check_player_via_search(client),
-        )
-    )
+    results.append(await run_check("player via search", lambda: _check_player_via_search(client)))
 
     return results
 
 
 async def _check_team_info(client: SofaScoreClient) -> str:
     info = await client.team.info.get_team_info(TEAM_ID)
-    return ok(f"{info.name} (id={info.id}, slug={info.slug})")
+    return ok(f"{info.name} (id={info.id})")
 
 
 async def _check_team_players(client: SofaScoreClient) -> str:
     data = await client.team.players.get_team_players(TEAM_ID)
     count = len(data.players or [])
-    first = data.players[0].player.name if data.players else "—"
-    return ok(f"{count} игроков, первый: {first}")
+    return ok(f"{count} игроков")
 
 
 async def _check_last_events(client: SofaScoreClient) -> str:
     data = await client.team.last_events.get_last_events(TEAM_ID, page=0)
-    count = len(data.events or [])
-    has_next = data.hasNextPage
-    return ok(f"{count} матчей на странице, hasNextPage={has_next}")
+    return ok(f"{len(data.events or [])} матчей, hasNextPage={data.hasNextPage}")
 
 
 async def _check_rankings(client: SofaScoreClient) -> str:
     data = await client.team.rankings.get_team_rankings(TEAM_ID)
-    count = len(data.rankings or [])
-    return ok(f"{count} записей рейтинга")
+    return ok(f"{len(data.rankings or [])} записей")
 
 
 async def _check_search_teams(client: SofaScoreClient) -> str:
@@ -180,96 +134,86 @@ async def _check_search_teams(client: SofaScoreClient) -> str:
         names.append(item.entity.name)
         if len(names) >= 3:
             break
-    return ok(f"найдено: {', '.join(names) or 'ничего'}")
+    return ok(", ".join(names) or "ничего")
 
 
 async def _check_live(client: SofaScoreClient) -> str:
     data = await client.live.get_live_events()
-    events = data.events or []
-    if not events:
-        return ok("live-матчей сейчас нет (это нормально)")
-    e = events[0]
-    home = e.homeTeam.name if e.homeTeam else "?"
-    away = e.awayTeam.name if e.awayTeam else "?"
-    status = e.status.type if e.status else "?"
-    return ok(f"{len(events)} live, пример: {home} vs {away} [{status}]")
+    return ok(f"{len(data.events or [])} live-матчей")
 
 
 async def _check_categories(client: SofaScoreClient) -> str:
     data = await client.tournament.get_categories()
-    cats = data.categories or []
-    sample = cats[0].name if cats else "—"
-    return ok(f"{len(cats)} категорий, пример: {sample}")
+    return ok(f"{len(data.categories or [])} категорий")
 
 
 async def _check_standings(client: SofaScoreClient, tournament_id: int) -> str:
     seasons = await client.tournament.get_seasons(tournament_id)
     if not seasons.seasons:
-        return ok("сезоны не найдены — пропуск standings")
-    season_id = seasons.seasons[0].id
-
-    data = await client.tournament.get_standings(tournament_id, season_id)
-    rows = data.rows or []
-    if not rows:
-        return ok("таблица пуста")
-    top = rows[0]
-    return ok(
-        f"лидер: {top.team.name} — {top.points} очков ({len(rows)} команд)"
-    )
+        return ok("сезоны не найдены")
+    data = await client.tournament.get_standings(tournament_id, seasons.seasons[0].id)
+    top = data.rows[0] if data.rows else None
+    return ok(f"лидер: {top.team.name} ({top.points} pts)" if top else "таблица пуста")
 
 
 async def _check_team_statistics(client: SofaScoreClient) -> str:
     seasons = await client.team.statistics_seasons.get_statistics_seasons(TEAM_ID)
     if not seasons.uniqueTournamentSeasons:
-        return ok("сезоны статистики не найдены")
+        return ok("нет сезонов")
     item = seasons.uniqueTournamentSeasons[0]
-    tournament = item.uniqueTournament
     season = item.seasons[0] if item.seasons else None
-    if not tournament or not season or not season.id:
-        return ok("нет данных турнира/сезона")
-    stats = await client.team.statistics.get_statistics(
-        TEAM_ID, tournament.id, season.id
-    )
-    keys = list((stats.statistics or {}).keys())[:4]
-    return ok(f"{tournament.name} / {season.name}: поля {keys}")
+    if not item.uniqueTournament or not season:
+        return ok("нет данных")
+    stats = await client.team.statistics.get_statistics(TEAM_ID, item.uniqueTournament.id, season.id)
+    return ok(f"полей статистики: {len(stats.statistics or {})}")
 
 
 async def _check_event_via_search(client: SofaScoreClient) -> str:
     event_id = None
     async for item in client.search.search_events(f"{SEARCH_QUERY} vs"):
-        if item.type == "event" and hasattr(item.entity, "id"):
-            event_id = item.entity.id
-            break
+        event_id = item.entity.id
+        break
     if not event_id:
-        return ok("матч через поиск не найден — пропуск event API")
-
+        return ok("матч не найден через search")
     event = await client.event.get_event(event_id)
-    home = event.homeTeam.name if event.homeTeam else "?"
-    away = event.awayTeam.name if event.awayTeam else "?"
-    stats = await client.event.get_statistics(event_id)
-    stat_count = sum(
-        len(g.statisticsItems or [])
-        for s in (stats.statistics or [])
-        for g in (s.groups or [])
-    )
-    return ok(f"id={event_id}: {home} vs {away}, {stat_count} метрик")
+    return ok(f"{event.homeTeam.name} vs {event.awayTeam.name}")
 
 
 async def _check_player_via_search(client: SofaScoreClient) -> str:
     player_id = None
     async for item in client.search.search_players("Bruno"):
-        if item.type == "player" and hasattr(item.entity, "id"):
-            player_id = item.entity.id
-            break
+        player_id = item.entity.id
+        break
     if not player_id:
-        return ok("игрок через поиск не найден — пропуск player API")
-
+        return ok("игрок не найден через search")
     player = await client.player.get_player(player_id)
-    team = player.team.name if player.team else "—"
-    return ok(f"{player.name} (id={player_id}), команда: {team}")
+    return ok(f"{player.name}")
 
 
-def print_summary(results: list[CheckResult]) -> int:
+def load_cookies(args: argparse.Namespace) -> dict[str, str]:
+    if args.cookies_file:
+        return load_cookies_from_file(args.cookies_file)
+    if args.cookie_header:
+        return parse_cookie_header(args.cookie_header)
+    if os.getenv("SOFASCORE_COOKIES_FILE"):
+        return load_cookies_from_file(os.environ["SOFASCORE_COOKIES_FILE"])
+    return {}
+
+
+def print_startup_info(args: argparse.Namespace, cookies: dict[str, str]) -> None:
+    transport = args.transport or os.getenv("SOFASCORE_TRANSPORT", "auto")
+    curl_ok = _curl_available()
+    print("Проверка aiosofascore")
+    print(f"  TEAM_ID={TEAM_ID}, SEARCH={SEARCH_QUERY!r}")
+    print(f"  transport={transport}, curl_cffi={'да' if curl_ok else 'нет'}")
+    print(f"  cookies: {len(cookies)} шт.")
+    if not cookies:
+        print("  ⚠ cookies не заданы")
+    if not curl_ok and transport in ("auto", "curl"):
+        print("  ⚠ Установите curl_cffi: pip install 'aiosofascore[curl]'")
+
+
+def print_summary(results: list[CheckResult], transport: str, has_cookies: bool) -> int:
     section("Итог")
     passed = sum(1 for r in results if r.ok)
     failed = len(results) - passed
@@ -278,10 +222,21 @@ def print_summary(results: list[CheckResult]) -> int:
 
     if failed and all("403" in r.detail for r in results if not r.ok):
         print(
-            "\n  Подсказка: все запросы вернули 403. SofaScore блокирует бота.\n"
-            "  Скопируйте cookies из браузера (DevTools → Network → api.sofascore.com)\n"
-            "  и задайте переменную окружения SOFASCORE_COOKIES:\n"
-            '\n    export SOFASCORE_COOKIES=\'{"имя_cookie": "значение"}\'\n'
+            "\n  Все запросы вернули 403. Cookies сами по себе часто НЕ помогают.\n"
+            "  SofaScore (Akamai) проверяет TLS-отпечаток клиента.\n"
+            "\n  Что сделать:\n"
+            "  1. pip install 'aiosofascore[curl]'\n"
+            "  2. Скопируйте Cookie из DevTools для запроса к api.sofascore.com\n"
+            "     (Network → api.sofascore.com → Headers → Cookie — целиком)\n"
+            "  3. Сохраните в cookies.txt и запустите:\n"
+            "     export SOFASCORE_COOKIES_FILE=cookies.txt\n"
+            "     export SOFASCORE_TRANSPORT=curl\n"
+            "     python examples/verify_library.py\n"
+            "\n  Важно:\n"
+            "  - Копируйте Cookie из запроса к API, не из document.cookie\n"
+            "  - Нужны HttpOnly cookies (_abck, bm_sz и др.) — их нет в document.cookie\n"
+            "  - Cookies быстро устаревают — копируйте прямо перед запуском\n"
+            f"  - Сейчас: transport={transport}, cookies={'есть' if has_cookies else 'нет'}\n"
         )
     elif failed:
         print("\n  Неудачные проверки:")
@@ -292,18 +247,40 @@ def print_summary(results: list[CheckResult]) -> int:
     return 0 if failed == 0 else 1
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Проверка aiosofascore")
+    parser.add_argument("--cookies-file", help="Файл cookies (JSON или строка Cookie из DevTools)")
+    parser.add_argument("--cookie-header", help="Строка Cookie из DevTools")
+    parser.add_argument(
+        "--transport",
+        choices=["auto", "aiohttp", "curl"],
+        default=None,
+        help="HTTP transport (по умолчанию auto → curl если установлен curl_cffi)",
+    )
+    return parser.parse_args()
+
+
 async def main() -> int:
-    print("Проверка aiosofascore")
-    print(f"  TEAM_ID={TEAM_ID}, TOURNAMENT_ID={TOURNAMENT_ID}, SEARCH={SEARCH_QUERY!r}")
+    args = parse_args()
+    cookies = load_cookies(args)
+    print_startup_info(args, cookies)
 
     try:
-        async with SofaScoreClient() as client:
+        async with SofaScoreClient(
+            cookies=cookies or None,
+            transport=args.transport,
+        ) as client:
+            print(f"  фактический transport: {client.http.transport}")
             results = await verify(client)
+    except ImportError as exc:
+        print(f"\n  Ошибка: {exc}")
+        return 1
     except Exception:
         traceback.print_exc()
         return 1
 
-    return print_summary(results)
+    transport = args.transport or os.getenv("SOFASCORE_TRANSPORT", "auto")
+    return print_summary(results, transport, bool(cookies))
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,8 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=["aiohttp", "pydantic"],
+    extras_require={
+        "curl": ["curl_cffi>=0.6.0"],
+    },
     python_requires=">=3.10",  # Укажите минимальную версию Python
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="aiosofascore",
-    version="0.2.0",
+    version="0.2.1",
     description="API client for SofaScore soccer data",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="aiosofascore",
-    version="0.1.2.0",
+    version="0.1.3.0",
     description="API client for SofaScore soccer data",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_packages
 
 setup(
     name="aiosofascore",
-    version="0.1.3.0",
+    version="0.2.0",
     description="API client for SofaScore soccer data",
-    long_description=open('README.md').read(),
+    long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     author="Philip",
     author_email="vasilewskij.fil@gmail.com",
@@ -15,9 +15,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=[
-        "aiohttp",
-        "pydantic"
-    ],
-    python_requires='>=3.10',  # Укажите минимальную версию Python
+    install_requires=["aiohttp", "pydantic"],
+    python_requires=">=3.10",  # Укажите минимальную версию Python
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ async def mock_client(
     team_last_events_responses,
 ):
     """Client with mocked HTTP responses for unit tests."""
-    client = SofaScoreClient(base_url="https://api.sofascore.com")
+    client = SofaScoreClient(base_url="https://www.sofascore.com")
 
     async def mock_get(path: str, params: dict | None = None):
         if path.startswith("/api/v1/team/") and path.endswith("/players"):
@@ -82,7 +82,7 @@ async def mock_client(
             )
         if path.startswith("/api/v1/team/"):
             return team_info_response
-        if path == "/v1/search/all":
+        if path == "/api/v1/search/all":
             if params and params.get("page", 0) > 0:
                 return {"results": []}
             return search_response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,19 +63,47 @@ async def mock_client(
     async def mock_get(path: str, params: dict | None = None):
         if path.startswith("/api/v1/team/") and path.endswith("/players"):
             return team_players_response
-        if path.endswith("/statistics/seasons"):
+        if path.endswith("/statistics/seasons") and "/player/" not in path:
             return team_statistics_seasons_response
-        if "/statistics/" in path:
+        if "/player/" in path and path.endswith("/statistics/seasons"):
+            return load_fixture("player_statistics_seasons.json")
+        if "/player/" in path and "/statistics/" in path:
+            return load_fixture("player_statistics.json")
+        if "/player/" in path and path.endswith("/transfer-history"):
+            return load_fixture("player_transfers.json")
+        if path.startswith("/api/v1/player/"):
+            return load_fixture("player_detail.json")
+        if "/team/" in path and "/statistics/" in path:
             return team_statistics_response
         if "/events/last/" in path:
             page = int(path.rsplit("/", 1)[-1])
-            return team_last_events_responses.get(page, {"events": [], "hasNextPage": False})
+            return team_last_events_responses.get(
+                page, {"events": [], "hasNextPage": False}
+            )
         if path.startswith("/api/v1/team/"):
             return team_info_response
         if path == "/v1/search/all":
             if params and params.get("page", 0) > 0:
                 return {"results": []}
             return search_response
+        if path.startswith("/api/v1/event/") and path.endswith("/statistics"):
+            return load_fixture("event_statistics.json")
+        if path.startswith("/api/v1/event/") and path.endswith("/lineups"):
+            return load_fixture("event_lineups.json")
+        if path.startswith("/api/v1/event/") and path.endswith("/incidents"):
+            return load_fixture("event_incidents.json")
+        if path.startswith("/api/v1/event/"):
+            return load_fixture("event_detail.json")
+        if path.endswith("/events/live"):
+            return load_fixture("live_events.json")
+        if path.endswith("/categories"):
+            return load_fixture("categories.json")
+        if path.endswith("/unique-tournaments"):
+            return load_fixture("unique_tournaments.json")
+        if "/unique-tournament/" in path and path.endswith("/seasons"):
+            return load_fixture("tournament_seasons.json")
+        if "/standings/" in path:
+            return load_fixture("standings.json")
         raise AssertionError(f"Unexpected API path: {path}")
 
     client.http.get = AsyncMock(side_effect=mock_get)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,14 +30,46 @@ def search_response():
     return load_fixture("search_results.json")
 
 
+@pytest.fixture
+def team_statistics_seasons_response():
+    return load_fixture("team_statistics_seasons.json")
+
+
+@pytest.fixture
+def team_statistics_response():
+    return load_fixture("team_statistics.json")
+
+
+@pytest.fixture
+def team_last_events_responses():
+    return {
+        0: load_fixture("team_last_events_page0.json"),
+        1: load_fixture("team_last_events_page1.json"),
+    }
+
+
 @pytest_asyncio.fixture
-async def mock_client(team_info_response, team_players_response, search_response):
+async def mock_client(
+    team_info_response,
+    team_players_response,
+    search_response,
+    team_statistics_seasons_response,
+    team_statistics_response,
+    team_last_events_responses,
+):
     """Client with mocked HTTP responses for unit tests."""
     client = SofaScoreClient(base_url="https://api.sofascore.com")
 
     async def mock_get(path: str, params: dict | None = None):
         if path.startswith("/api/v1/team/") and path.endswith("/players"):
             return team_players_response
+        if path.endswith("/statistics/seasons"):
+            return team_statistics_seasons_response
+        if "/statistics/" in path:
+            return team_statistics_response
+        if "/events/last/" in path:
+            page = int(path.rsplit("/", 1)[-1])
+            return team_last_events_responses.get(page, {"events": [], "hasNextPage": False})
         if path.startswith("/api/v1/team/"):
             return team_info_response
         if path == "/v1/search/all":

--- a/tests/fixtures/categories.json
+++ b/tests/fixtures/categories.json
@@ -1,0 +1,11 @@
+{
+  "categories": [
+    {
+      "id": 1,
+      "name": "England",
+      "slug": "england",
+      "flag": "england",
+      "sport": {"id": 1, "name": "Football", "slug": "football"}
+    }
+  ]
+}

--- a/tests/fixtures/event_detail.json
+++ b/tests/fixtures/event_detail.json
@@ -1,0 +1,14 @@
+{
+  "event": {
+    "id": 11352523,
+    "slug": "arsenal-chelsea",
+    "customId": "ArsChe",
+    "startTimestamp": 1700000000,
+    "status": {"code": 100, "description": "Ended", "type": "finished"},
+    "homeTeam": {"id": 42, "name": "Arsenal", "slug": "arsenal"},
+    "awayTeam": {"id": 38, "name": "Chelsea", "slug": "chelsea"},
+    "homeScore": {"current": 2, "display": 2},
+    "awayScore": {"current": 1, "display": 1},
+    "tournament": {"id": 1, "name": "Premier League", "slug": "premier-league"}
+  }
+}

--- a/tests/fixtures/event_incidents.json
+++ b/tests/fixtures/event_incidents.json
@@ -1,0 +1,12 @@
+{
+  "incidents": [
+    {
+      "id": 1,
+      "time": 23,
+      "incidentType": "goal",
+      "isHome": true,
+      "homeScore": 1,
+      "awayScore": 0
+    }
+  ]
+}

--- a/tests/fixtures/event_lineups.json
+++ b/tests/fixtures/event_lineups.json
@@ -1,0 +1,11 @@
+{
+  "confirmed": true,
+  "home": {
+    "formation": "4-3-3",
+    "players": [{"player": {"id": 1, "name": "Player A"}, "shirtNumber": 1}]
+  },
+  "away": {
+    "formation": "4-2-3-1",
+    "players": [{"player": {"id": 2, "name": "Player B"}, "shirtNumber": 9}]
+  }
+}

--- a/tests/fixtures/event_statistics.json
+++ b/tests/fixtures/event_statistics.json
@@ -1,0 +1,16 @@
+{
+  "statistics": [
+    {
+      "period": "ALL",
+      "groups": [
+        {
+          "groupName": "Match overview",
+          "statisticsItems": [
+            {"name": "Ball possession", "home": "57%", "away": "43%"},
+            {"name": "Total shots", "home": "14", "away": "7"}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/live_events.json
+++ b/tests/fixtures/live_events.json
@@ -1,0 +1,14 @@
+{
+  "events": [
+    {
+      "id": 99901,
+      "slug": "live-match",
+      "startTimestamp": 1700000000,
+      "status": {"code": 31, "description": "1st half", "type": "inprogress"},
+      "homeTeam": {"id": 42, "name": "Arsenal", "slug": "arsenal"},
+      "awayTeam": {"id": 38, "name": "Chelsea", "slug": "chelsea"},
+      "homeScore": {"current": 1, "display": 1},
+      "awayScore": {"current": 0, "display": 0}
+    }
+  ]
+}

--- a/tests/fixtures/player_detail.json
+++ b/tests/fixtures/player_detail.json
@@ -1,0 +1,11 @@
+{
+  "player": {
+    "id": 12345,
+    "name": "Bruno Fernandes",
+    "slug": "bruno-fernandes",
+    "shortName": "B. Fernandes",
+    "position": "M",
+    "jerseyNumber": "8",
+    "team": {"id": 2819, "name": "Manchester United", "slug": "manchester-united"}
+  }
+}

--- a/tests/fixtures/player_statistics.json
+++ b/tests/fixtures/player_statistics.json
@@ -1,0 +1,8 @@
+{
+  "statistics": {
+    "goals": 15,
+    "assists": 10,
+    "rating": 7.45,
+    "matches": 34
+  }
+}

--- a/tests/fixtures/player_statistics_seasons.json
+++ b/tests/fixtures/player_statistics_seasons.json
@@ -1,0 +1,8 @@
+{
+  "uniqueTournamentSeasons": [
+    {
+      "uniqueTournament": {"id": 17, "name": "Premier League", "slug": "premier-league"},
+      "seasons": [{"id": 52186, "name": "Premier League 23/24", "year": "23/24"}]
+    }
+  ]
+}

--- a/tests/fixtures/player_transfers.json
+++ b/tests/fixtures/player_transfers.json
@@ -1,0 +1,11 @@
+{
+  "transferHistory": [
+    {
+      "id": 1,
+      "transferDateTimestamp": 1600000000,
+      "fromTeamName": "Sporting CP",
+      "toTeamName": "Manchester United",
+      "transferFeeDescription": "€55M"
+    }
+  ]
+}

--- a/tests/fixtures/standings.json
+++ b/tests/fixtures/standings.json
@@ -1,0 +1,20 @@
+{
+  "standings": [
+    {
+      "id": 1,
+      "name": "Premier League",
+      "rows": [
+        {
+          "id": 1,
+          "position": 1,
+          "points": 80,
+          "matches": 34,
+          "wins": 25,
+          "draws": 5,
+          "losses": 4,
+          "team": {"id": 42, "name": "Arsenal", "slug": "arsenal"}
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/team_last_events_page0.json
+++ b/tests/fixtures/team_last_events_page0.json
@@ -1,0 +1,12 @@
+{
+  "events": [
+    {
+      "id": 1001,
+      "slug": "team-a-team-b",
+      "startTimestamp": 1700000000,
+      "homeTeam": {"id": 1, "name": "Team A", "slug": "team-a"},
+      "awayTeam": {"id": 2, "name": "Team B", "slug": "team-b"}
+    }
+  ],
+  "hasNextPage": true
+}

--- a/tests/fixtures/team_last_events_page1.json
+++ b/tests/fixtures/team_last_events_page1.json
@@ -1,0 +1,12 @@
+{
+  "events": [
+    {
+      "id": 1002,
+      "slug": "team-c-team-d",
+      "startTimestamp": 1699900000,
+      "homeTeam": {"id": 3, "name": "Team C", "slug": "team-c"},
+      "awayTeam": {"id": 4, "name": "Team D", "slug": "team-d"}
+    }
+  ],
+  "hasNextPage": false
+}

--- a/tests/fixtures/team_statistics.json
+++ b/tests/fixtures/team_statistics.json
@@ -1,0 +1,10 @@
+{
+  "statistics": {
+    "matches": 38,
+    "goalsScored": 57,
+    "goalsConceded": 44,
+    "assists": 42,
+    "avgRating": 6.95,
+    "ballPossession": 54.2
+  }
+}

--- a/tests/fixtures/team_statistics_seasons.json
+++ b/tests/fixtures/team_statistics_seasons.json
@@ -1,0 +1,15 @@
+{
+  "uniqueTournamentSeasons": [
+    {
+      "uniqueTournament": {
+        "id": 17,
+        "name": "Premier League",
+        "slug": "premier-league"
+      },
+      "seasons": [
+        {"id": 52186, "name": "Premier League 23/24", "year": "23/24"},
+        {"id": 48982, "name": "Premier League 22/23", "year": "22/23"}
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/tournament_seasons.json
+++ b/tests/fixtures/tournament_seasons.json
@@ -1,0 +1,5 @@
+{
+  "seasons": [
+    {"id": 52186, "name": "Premier League 23/24", "year": "23/24", "editor": false}
+  ]
+}

--- a/tests/fixtures/unique_tournaments.json
+++ b/tests/fixtures/unique_tournaments.json
@@ -1,0 +1,14 @@
+{
+  "groups": [
+    {
+      "uniqueTournaments": [
+        {
+          "id": 17,
+          "name": "Premier League",
+          "slug": "premier-league",
+          "userCount": 1000000
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_event_mock.py
+++ b/tests/test_event_mock.py
@@ -1,0 +1,32 @@
+import pytest
+
+EVENT_ID = 11352523
+
+
+@pytest.mark.asyncio
+async def test_get_event(mock_client):
+    event = await mock_client.event.get_event(EVENT_ID)
+    assert event.id == EVENT_ID
+    assert event.homeTeam.name == "Arsenal"
+    assert event.awayTeam.name == "Chelsea"
+
+
+@pytest.mark.asyncio
+async def test_get_event_statistics(mock_client):
+    stats = await mock_client.event.get_statistics(EVENT_ID)
+    assert stats.statistics is not None
+    assert stats.statistics[0].groups[0].statisticsItems[0].name == "Ball possession"
+
+
+@pytest.mark.asyncio
+async def test_get_event_lineups(mock_client):
+    lineups = await mock_client.event.get_lineups(EVENT_ID)
+    assert lineups.confirmed is True
+    assert lineups.home["formation"] == "4-3-3"
+
+
+@pytest.mark.asyncio
+async def test_get_event_incidents(mock_client):
+    incidents = await mock_client.event.get_incidents(EVENT_ID)
+    assert len(incidents.incidents) == 1
+    assert incidents.incidents[0].incidentType == "goal"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -56,7 +56,9 @@ async def test_lazy_session_open_on_get():
 
 @pytest.mark.asyncio
 async def test_retry_on_retryable_status():
-    http = HttpSessionManager(max_retries=2, retry_base_delay=0.01, transport="aiohttp", warmup=False)
+    http = HttpSessionManager(
+        max_retries=2, retry_base_delay=0.01, transport="aiohttp", warmup=False
+    )
 
     call_count = 0
 
@@ -91,7 +93,9 @@ async def test_retry_on_retryable_status():
 
 @pytest.mark.asyncio
 async def test_raises_after_max_retries():
-    http = HttpSessionManager(max_retries=1, retry_base_delay=0.01, transport="aiohttp", warmup=False)
+    http = HttpSessionManager(
+        max_retries=1, retry_base_delay=0.01, transport="aiohttp", warmup=False
+    )
 
     resp = MagicMock()
     resp.status = 403

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -8,13 +8,13 @@ from aiosofascore.exception import ResponseParseContentError
 
 @pytest.mark.asyncio
 async def test_default_base_url():
-    http = HttpSessionManager()
+    http = HttpSessionManager(transport="aiohttp")
     assert http.base_url == DEFAULT_BASE_URL
 
 
 @pytest.mark.asyncio
 async def test_session_reuse():
-    http = HttpSessionManager()
+    http = HttpSessionManager(transport="aiohttp")
     await http.open()
     session = http._session
     await http.open()
@@ -25,17 +25,18 @@ async def test_session_reuse():
 
 @pytest.mark.asyncio
 async def test_context_manager_closes_session():
-    async with HttpSessionManager() as http:
+    async with HttpSessionManager(transport="aiohttp") as http:
         assert http.is_open
     assert not http.is_open
 
 
 @pytest.mark.asyncio
 async def test_lazy_session_open_on_get():
-    http = HttpSessionManager()
+    http = HttpSessionManager(transport="aiohttp", warmup=False)
     assert not http.is_open
 
     mock_response = MagicMock()
+    mock_response.status = 200
     mock_response.ok = True
     mock_response.json = AsyncMock(return_value={"ok": True})
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
@@ -48,13 +49,14 @@ async def test_lazy_session_open_on_get():
     with patch.object(http, "open", wraps=http.open) as open_mock:
         with patch.object(HttpSessionManager, "_session", mock_session, create=True):
             http._session = mock_session
+            http.transport = "aiohttp"
             result = await http.get("/api/v1/test")
             assert result == {"ok": True}
 
 
 @pytest.mark.asyncio
 async def test_retry_on_retryable_status():
-    http = HttpSessionManager(max_retries=2, retry_base_delay=0.01)
+    http = HttpSessionManager(max_retries=2, retry_base_delay=0.01, transport="aiohttp", warmup=False)
 
     call_count = 0
 
@@ -81,6 +83,7 @@ async def test_retry_on_retryable_status():
     mock_session.get = mock_get
 
     http._session = mock_session
+    http.transport = "aiohttp"
     result = await http.get("/api/v1/test")
     assert result == {"data": "ok"}
     assert call_count == 3
@@ -88,7 +91,7 @@ async def test_retry_on_retryable_status():
 
 @pytest.mark.asyncio
 async def test_raises_after_max_retries():
-    http = HttpSessionManager(max_retries=1, retry_base_delay=0.01)
+    http = HttpSessionManager(max_retries=1, retry_base_delay=0.01, transport="aiohttp", warmup=False)
 
     resp = MagicMock()
     resp.status = 403
@@ -101,13 +104,14 @@ async def test_raises_after_max_retries():
     mock_session.get = MagicMock(return_value=resp)
 
     http._session = mock_session
+    http.transport = "aiohttp"
     with pytest.raises(ResponseParseContentError):
         await http.get("/api/v1/test")
 
 
 @pytest.mark.asyncio
 async def test_set_cookies():
-    http = HttpSessionManager(cookies={"test": "value"})
+    http = HttpSessionManager(cookies={"test": "value"}, transport="aiohttp")
     assert http.cookies["test"] == "value"
     http.set_cookies({"extra": "cookie"})
     assert http.cookies["extra"] == "cookie"

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+import pytest_asyncio
+
+from aiosofascore.client import SofaScoreClient
+
+pytestmark = pytest.mark.integration(
+    skipif=not os.getenv("SOFASCORE_LIVE"),
+    reason="Set SOFASCORE_LIVE=1 to run live API tests",
+)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def client():
+    async with SofaScoreClient() as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_get_live_events(client):
+    live = await client.live.get_live_events()
+    assert hasattr(live, "events")
+
+
+@pytest.mark.asyncio
+async def test_get_categories(client):
+    categories = await client.tournament.get_categories()
+    assert hasattr(categories, "categories")
+
+
+@pytest.mark.asyncio
+async def test_get_event(client):
+    # Use a known finished event id if available; skip if empty search
+    results = []
+    async for item in client.search.search_events("Arsenal Chelsea"):
+        if item.type == "event":
+            results.append(item)
+            break
+    if not results:
+        pytest.skip("No event found via search")
+    event_id = results[0].entity.id
+    event = await client.event.get_event(event_id)
+    assert event.id == event_id

--- a/tests/test_live_mock.py
+++ b/tests/test_live_mock.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_live_events(mock_client):
+    live = await mock_client.live.get_live_events()
+    assert live.events is not None
+    assert len(live.events) == 1
+    assert live.events[0].status.type == "inprogress"

--- a/tests/test_player_mock.py
+++ b/tests/test_player_mock.py
@@ -1,0 +1,30 @@
+import pytest
+
+PLAYER_ID = 12345
+TOURNAMENT_ID = 17
+SEASON_ID = 52186
+
+
+@pytest.mark.asyncio
+async def test_get_player(mock_client):
+    player = await mock_client.player.get_player(PLAYER_ID)
+    assert player.id == PLAYER_ID
+    assert player.name == "Bruno Fernandes"
+
+
+@pytest.mark.asyncio
+async def test_get_player_statistics_seasons(mock_client):
+    seasons = await mock_client.player.get_statistics_seasons(PLAYER_ID)
+    assert seasons.uniqueTournamentSeasons[0].uniqueTournament.name == "Premier League"
+
+
+@pytest.mark.asyncio
+async def test_get_player_statistics(mock_client):
+    stats = await mock_client.player.get_statistics(PLAYER_ID, TOURNAMENT_ID, SEASON_ID)
+    assert stats.statistics["goals"] == 15
+
+
+@pytest.mark.asyncio
+async def test_get_player_transfers(mock_client):
+    transfers = await mock_client.player.get_transfers(PLAYER_ID)
+    assert transfers.transferHistory[0].toTeamName == "Manchester United"

--- a/tests/test_search_mock.py
+++ b/tests/test_search_mock.py
@@ -1,12 +1,10 @@
 import pytest
 
-from aiosofascore.client import SofaScoreClient
-
 
 @pytest.mark.asyncio
 async def test_search_all_entities(mock_client):
     results = []
-    async for item in mock_client.search.search.search_entities("Manchester"):
+    async for item in mock_client.search.search_all("Manchester"):
         results.append(item)
     assert len(results) == 2
     assert results[0].type == "team"
@@ -16,9 +14,7 @@ async def test_search_all_entities(mock_client):
 @pytest.mark.asyncio
 async def test_search_teams_only(mock_client):
     results = []
-    async for item in mock_client.search.search.search_entities(
-        "Manchester", type="team"
-    ):
+    async for item in mock_client.search.search_teams("Manchester"):
         results.append(item)
     assert len(results) == 1
     assert results[0].entity.name == "Manchester United"
@@ -27,9 +23,15 @@ async def test_search_teams_only(mock_client):
 @pytest.mark.asyncio
 async def test_search_players_only(mock_client):
     results = []
-    async for item in mock_client.search.search.search_entities(
-        "Manchester", type="player"
-    ):
+    async for item in mock_client.search.search_players("Manchester"):
         results.append(item)
     assert len(results) == 1
     assert results[0].entity.name == "Bruno Fernandes"
+
+
+@pytest.mark.asyncio
+async def test_search_entities_backward_compat(mock_client):
+    results = []
+    async for item in mock_client.search.search_entities("Manchester", type="team"):
+        results.append(item)
+    assert len(results) == 1

--- a/tests/test_team_services.py
+++ b/tests/test_team_services.py
@@ -60,3 +60,9 @@ async def test_get_team_last_events(client):
     last_events = await client.team.last_events.get_last_events(TEAM_ID, PAGE)
     assert hasattr(last_events, "events")
     assert hasattr(last_events, "hasNextPage")
+
+
+@pytest.mark.asyncio
+async def test_get_statistics_seasons(client):
+    seasons = await client.team.statistics_seasons.get_statistics_seasons(TEAM_ID)
+    assert hasattr(seasons, "uniqueTournamentSeasons")

--- a/tests/test_team_statistics_mock.py
+++ b/tests/test_team_statistics_mock.py
@@ -1,0 +1,35 @@
+import pytest
+
+TEAM_ID = 2819
+TOURNAMENT_ID = 17
+SEASON_ID = 52186
+
+
+@pytest.mark.asyncio
+async def test_get_statistics_seasons(mock_client):
+    result = await mock_client.team.statistics_seasons.get_statistics_seasons(TEAM_ID)
+    assert result.uniqueTournamentSeasons is not None
+    assert len(result.uniqueTournamentSeasons) == 1
+    item = result.uniqueTournamentSeasons[0]
+    assert item.uniqueTournament.name == "Premier League"
+    assert len(item.seasons) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_statistics(mock_client):
+    result = await mock_client.team.statistics.get_statistics(
+        TEAM_ID, TOURNAMENT_ID, SEASON_ID
+    )
+    assert result.statistics is not None
+    assert result.statistics["goalsScored"] == 57
+    assert result.statistics["matches"] == 38
+
+
+@pytest.mark.asyncio
+async def test_iter_last_events(mock_client):
+    events = []
+    async for event in mock_client.team.last_events.iter_last_events(TEAM_ID):
+        events.append(event)
+    assert len(events) == 2
+    assert events[0].id == 1001
+    assert events[1].id == 1002

--- a/tests/test_tournament_mock.py
+++ b/tests/test_tournament_mock.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_categories(mock_client):
+    categories = await mock_client.tournament.get_categories()
+    assert categories.categories is not None
+    assert categories.categories[0].name == "England"
+
+
+@pytest.mark.asyncio
+async def test_get_unique_tournaments(mock_client):
+    tournaments = await mock_client.tournament.get_unique_tournaments(1)
+    items = tournaments.unique_tournaments
+    assert len(items) == 1
+    assert items[0].name == "Premier League"
+
+
+@pytest.mark.asyncio
+async def test_get_seasons(mock_client):
+    seasons = await mock_client.tournament.get_seasons(17)
+    assert seasons.seasons[0].year == "23/24"
+
+
+@pytest.mark.asyncio
+async def test_get_standings(mock_client):
+    standings = await mock_client.tournament.get_standings(17, 52186)
+    assert standings.rows[0].team.name == "Arsenal"
+    assert standings.rows[0].position == 1
+
+
+@pytest.mark.asyncio
+async def test_get_standings_by_year(mock_client):
+    standings = await mock_client.tournament.get_standings_by_year(17, "23/24")
+    assert standings.rows[0].points == 80


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the full aiosofascore update roadmap (Phases 0–3) in a single release **v0.2.0**.

### Phase 0 — Infrastructure
- Reusable HTTP session, retry on 403/429/5xx, configurable cookies/proxy
- `async with SofaScoreClient()` context manager
- Mock-based unit tests + CI test workflow

### Phase 1 — Existing services
- Search UX: `client.search.search_teams()` etc. (no more `client.search.search.search_*`)
- Team statistics seasons/stats, `iter_last_events` pagination

### Phase 2 — New services
| Service | Methods |
|---------|---------|
| `client.event` | `get_event`, `get_lineups`, `get_statistics`, `get_incidents`, `get_h2h`, `get_pregame_form`, `get_managers` |
| `client.live` | `get_live_events(sport="football")` |
| `client.tournament` | `get_categories`, `get_unique_tournaments`, `get_seasons`, `get_standings`, `get_standings_by_year` |
| `client.player` | `get_player`, `get_statistics_seasons`, `get_statistics`, `get_transfers` |

### Phase 3 — Quality & DX
- Shared `BaseRepository` with `_get_wrapped` helper
- **31 unit tests** with JSON fixtures
- Updated README (RU/EN), CHANGELOG, `examples/all_services.py`
- CI: `black --check` in test workflow
- PyPI publish triggers on version tags (`v*`) only

## Breaking changes since 0.1.x
- `client.search.search.*` → `client.search.*`
- Hardcoded cookies removed; pass cookies via constructor or `SOFASCORE_COOKIES`
- Recommended: `async with SofaScoreClient() as client:`

## Test plan
- [x] `pytest tests/ -m "not integration" -v` — 31 passed
- [x] `black --check .`
- [ ] `SOFASCORE_LIVE=1 pytest tests/ -m integration`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21f70b23-d570-4561-a59f-1debf34d0b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21f70b23-d570-4561-a59f-1debf34d0b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

